### PR TITLE
Reduce sudo usage and exec calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@ A scalable, multi-architecture testing infrastructure for Kubernetes using funct
 
 ### Development Setup
 
-1. **Clone the repository**:
+1. **Install astral**:
+   ```bash
+   sudo snap install astral-uv --classic
+   ```
+
+2. **Clone the repository**:
    ```bash
    git clone https://github.com/canonical/kube-galaxy-test.git
    cd kube-galaxy-test
    ```
 
-2. **Create Python environment** (using `uv`):
+3. **Create Python environment** (using `uv`):
    ```bash
    uv venv
    source .venv/bin/activate
@@ -39,9 +44,9 @@ A scalable, multi-architecture testing infrastructure for Kubernetes using funct
    source .venv/bin/activate
    ```
 
-3. **Install kube-galaxy with dev dependencies**:
+4. **Install kube-galaxy with dev dependencies**:
    ```bash
-   uv tool install -e .
+   uv pip install -e .
    ```
 
 ### Basic Usage
@@ -56,12 +61,17 @@ A scalable, multi-architecture testing infrastructure for Kubernetes using funct
    kube-galaxy test-manifest manifests/baseline-k8s-1.35.yaml
    ```
 
-3. **Check project status**:
+3. **Setup the cluster**:
+   ```bash
+   kube-galaxy setup manifests/baseline-k8s-1.35.yaml
+   ```
+
+4. **Check project status**:
    ```bash
    kube-galaxy status
    ```
 
-4. **Run tests**:
+5. **Run tests**:
    ```bash
    # Run local validation tests
    kube-galaxy test local

--- a/src/kube_galaxy/pkg/cluster.py
+++ b/src/kube_galaxy/pkg/cluster.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from kube_galaxy.pkg.arch.detector import ArchInfo, get_arch_info
 from kube_galaxy.pkg.components import COMPONENTS, ComponentBase
+from kube_galaxy.pkg.literals import Commands
 from kube_galaxy.pkg.manifest.loader import load_manifest
 from kube_galaxy.pkg.manifest.models import ComponentConfig
 from kube_galaxy.pkg.utils.errors import ClusterError
@@ -352,9 +353,7 @@ def _cleanup_kube_galaxy_alternatives(force: bool) -> None:
                             try:
                                 run(
                                     [
-                                        "sudo",
-                                        "update-alternatives",
-                                        "--remove",
+                                        *Commands.UPDATE_ALTERNATIVES_REMOVE,
                                         binary.name,
                                         str(binary),
                                     ],
@@ -365,7 +364,7 @@ def _cleanup_kube_galaxy_alternatives(force: bool) -> None:
 
         # Remove the entire /opt/kube-galaxy directory
         try:
-            run(["sudo", "rm", "-rf", str(kube_galaxy_dir)], check=False)
+            run([*Commands.SUDO_RM_RF, str(kube_galaxy_dir)], check=False)
             info(f"  Removed {kube_galaxy_dir}")
         except Exception as e:
             if force:

--- a/src/kube_galaxy/pkg/components/_base.py
+++ b/src/kube_galaxy/pkg/components/_base.py
@@ -288,7 +288,7 @@ class ComponentBase:
         """
         Remove all alternatives for binaries in this component's bin directory.
         """
-        component_bin_dir = Path(self.component_dir) / "bin"
+        component_bin_dir = SystemPaths.component_bin_dir(self.name)
         if component_bin_dir.exists():
             for binary in component_bin_dir.glob("*"):
                 if binary.is_file():
@@ -349,7 +349,7 @@ class ComponentBase:
             Path to component temp directory
         """
         temp_dir = Path(self.component_tmp_dir)
-        run([*Commands.SUDO_MKDIR_P, str(temp_dir)], check=True)
+        temp_dir.mkdir(parents=True, exist_ok=True)
         return temp_dir
 
     def download_binary_from_config(self, arch: str, binary_name: str | None = None) -> Path:
@@ -469,13 +469,17 @@ class ComponentBase:
         """
         try:
             run([*Commands.SYSTEMCTL_STOP, service_name], check=False)
-            run(["sudo", "systemctl", "disable", service_name], check=False)
+            run([*Commands.SYSTEMCTL_DISABLE, service_name], check=False)
             info(f"Stopped {service_name} service")
         except Exception as e:
             info(f"Failed to stop {service_name} service: {e}")
 
     def create_systemd_service(
-        self, service_name: str, service_content: str, system_location: bool = True
+        self,
+        service_name: str,
+        service_content: str,
+        system_location: bool = True,
+        enabled: bool = False,
     ) -> None:
         """
         Create a systemd service file.
@@ -492,18 +496,23 @@ class ComponentBase:
             # Write to temp file first
             temp_dir = self.ensure_temp_dir()
             temp_unit = temp_dir / f"{service_name}.service"
-            run([*Commands.SUDO_TEE, str(temp_unit)], input=service_content, text=True, check=True)
+            temp_unit.write_text(service_content)
 
             # Create target directory and copy
             target_dir = "/etc/systemd/system" if system_location else "/usr/lib/systemd/system"
             target_path = f"{target_dir}/{service_name}.service"
             run([*Commands.SUDO_MKDIR_P, target_dir], check=True)
             run([*Commands.SUDO_CP, str(temp_unit), target_path], check=True)
+
+            # Reload systemd and enable service
+            run([*Commands.SYSTEMCTL_DAEMON_RELOAD], check=True)
+            if enabled:
+                run([*Commands.SYSTEMCTL_ENABLE, service_name], check=True)
         except Exception as e:
             raise ComponentError(f"Failed to create {service_name} service: {e}") from e
 
     def write_config_file(
-        self, config_content: str, target_path: str, mode: str = Permissions.READABLE
+        self, config_content: str, target_path: str | Path, mode: str = Permissions.READABLE
     ) -> None:
         """
         Write configuration content to a file via temporary file.
@@ -519,12 +528,12 @@ class ComponentBase:
         try:
             temp_dir = self.ensure_temp_dir()
             temp_config = temp_dir / "config"
+            temp_config.write_text(config_content)
 
             # Write to temp file, then copy and set permissions
-            run([*Commands.SUDO_TEE, str(temp_config)], input=config_content, text=True, check=True)
             run([*Commands.SUDO_MKDIR_P, str(Path(target_path).parent)], check=True)
-            run([*Commands.SUDO_CP, str(temp_config), target_path], check=True)
-            run([*Commands.SUDO_CHMOD, mode, target_path], check=True)
+            run([*Commands.SUDO_CP, str(temp_config), str(target_path)], check=True)
+            run([*Commands.SUDO_CHMOD, mode, str(target_path)], check=True)
         except Exception as e:
             raise ComponentError(f"Failed to write config to {target_path}: {e}") from e
 
@@ -539,7 +548,7 @@ class ComponentBase:
             ComponentError: If service is not active
         """
         try:
-            run(["sudo", "systemctl", "is-active", service_name], check=True)
+            run([*Commands.SYSTEMCTL_IS_ACTIVE, service_name], check=True)
         except Exception as e:
             raise ComponentError(f"Service {service_name} is not active: {e}") from e
 
@@ -595,7 +604,7 @@ class ComponentBase:
             config_file = Path(config_path)
             if config_file.exists():
                 try:
-                    run(["sudo", "rm", "-f", str(config_file)], check=False)
+                    run([*Commands.SUDO_RM_RF, str(config_file)], check=False)
                     info(f"Removed {name} config: {config_file}")
                 except Exception as e:
                     info(f"Failed to remove {config_file}: {e}")

--- a/src/kube_galaxy/pkg/components/containerd.py
+++ b/src/kube_galaxy/pkg/components/containerd.py
@@ -4,10 +4,10 @@ Containerd component installation and management.
 Containerd is the container runtime used by Kubernetes clusters.
 """
 
-from pathlib import Path
 from typing import ClassVar
 
 from kube_galaxy.pkg.components import ComponentBase, register_component
+from kube_galaxy.pkg.literals import Commands, Permissions
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.shell import run
@@ -56,7 +56,7 @@ class Containerd(ComponentBase):
     def pre_install_hook(self) -> None:
         """Remove any existing containerd installation to avoid conflicts."""
         info("  Removing existing containerd installation if present")
-        run(["sudo", "apt", "remove", "-y", "containerd.io"], check=False)
+        run([*Commands.SUDO_APT_REMOVE, "-y", "containerd.io"], check=False)
 
     def install_hook(self, arch: str) -> None:
         """
@@ -99,14 +99,9 @@ class Containerd(ComponentBase):
         )
 
         # Write containerd config to /etc/containerd/config.toml
-        run(["sudo", "mkdir", "-p", "/etc/containerd"], check=True)
-        temp_config = Path(self.component_tmp_dir) / "config.toml"
-        run(["sudo", "mkdir", "-p", str(temp_config.parent)], check=True)
-
-        # Write config content to temp file with proper permissions
-        run(["sudo", "tee", str(temp_config)], input=config_content, text=True, check=True)
-        run(["sudo", "cp", str(temp_config), "/etc/containerd/config.toml"], check=True)
-        run(["sudo", "chmod", "644", "/etc/containerd/config.toml"], check=True)
+        self.write_config_file(
+            config_content, "/etc/containerd/config.toml", mode=Permissions.READABLE
+        )
 
         # Create systemd service unit
         systemd_unit = """[Unit]
@@ -129,23 +124,13 @@ LimitNPROC=infinity
 WantedBy=multi-user.target
 """
 
-        # Write to temporary file first, then copy with sudo
-        temp_unit = Path(self.component_tmp_dir) / "containerd.service"
-
-        # Write service content to temp file with proper permissions
-        run(["sudo", "tee", str(temp_unit)], input=systemd_unit, text=True, check=True)
-        run(["sudo", "mkdir", "-p", "/etc/systemd/system"], check=True)
-        run(["sudo", "cp", str(temp_unit), "/etc/systemd/system/containerd.service"], check=True)
-
-        # Reload systemd and enable service
-        run(["sudo", "systemctl", "daemon-reload"], check=True)
-        run(["sudo", "systemctl", "enable", "containerd"], check=True)
+        self.create_systemd_service("containerd", systemd_unit, enabled=True)
 
     def bootstrap_hook(self) -> None:
         """
         Start containerd service.
         """
-        run(["sudo", "systemctl", "start", "containerd"], check=True)
+        run([*Commands.SYSTEMCTL_START, "containerd"], check=True)
 
     def verify_hook(self) -> None:
         """
@@ -154,7 +139,7 @@ WantedBy=multi-user.target
         Checks service status and command availability.
         """
         # Check service is active
-        run(["sudo", "systemctl", "is-active", "containerd"], check=True)
+        run([*Commands.SYSTEMCTL_IS_ACTIVE, "containerd"], check=True)
 
         # Check containerd command works
         run(["containerd", "--version"], check=True)
@@ -167,7 +152,7 @@ WantedBy=multi-user.target
         """
         try:
             # Stop containerd service
-            run(["sudo", "systemctl", "stop", "containerd"], check=False)
+            run([*Commands.SYSTEMCTL_STOP, "containerd"], check=False)
             info("Stopped containerd service")
 
             # TODO: Add crictl commands to remove containers and images
@@ -201,8 +186,8 @@ WantedBy=multi-user.target
         """
         # Disable and reload systemd if service still exists
         try:
-            run(["sudo", "systemctl", "disable", "containerd"], check=False)
-            run(["sudo", "systemctl", "daemon-reload"], check=False)
+            run([*Commands.SYSTEMCTL_DISABLE, "containerd"], check=False)
+            run([*Commands.SYSTEMCTL_DAEMON_RELOAD], check=False)
             info("Disabled containerd service")
         except Exception:
             pass

--- a/src/kube_galaxy/pkg/components/kubeadm.py
+++ b/src/kube_galaxy/pkg/components/kubeadm.py
@@ -12,7 +12,7 @@ from urllib.request import urlopen
 import yaml
 
 from kube_galaxy.pkg.components import ComponentBase, register_component
-from kube_galaxy.pkg.literals import URLs
+from kube_galaxy.pkg.literals import Commands, URLs
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.shell import run
@@ -89,11 +89,16 @@ class Kubeadm(ComponentBase):
                 )
                 config["clusterName"] = self.manifest.name
         self._cluster_config = Path(self.component_tmp_dir) / "kubeadm-config.yaml"
-        run(["sudo", "mkdir", "-p", str(self._cluster_config.parent)], check=True)
+        run([*Commands.SUDO_MKDIR_P, str(self._cluster_config.parent)], check=True)
 
         # Write config to temp file via sudo
         config_content = yaml.safe_dump_all(configs)
-        run(["sudo", "tee", str(self._cluster_config)], input=config_content, text=True, check=True)
+        run(
+            [*Commands.SUDO_TEE, str(self._cluster_config)],
+            input=config_content,
+            text=True,
+            check=True,
+        )
 
     def bootstrap_hook(self) -> None:
         """
@@ -121,14 +126,14 @@ class Kubeadm(ComponentBase):
 
         # Copy admin config
         run(
-            ["sudo", "cp", "/etc/kubernetes/admin.conf", str(kube_dir / "config")],
+            [*Commands.SUDO_CP, "/etc/kubernetes/admin.conf", str(kube_dir / "config")],
             check=True,
         )
 
         # Set proper ownership
         owner = home.owner()
         group = home.group()
-        run(["sudo", "chown", f"{owner}:{group}", str(kube_dir / "config")], check=True)
+        run([*Commands.SUDO_CHOWN, f"{owner}:{group}", str(kube_dir / "config")], check=True)
 
     def verify_hook(self) -> None:
         """

--- a/src/kube_galaxy/pkg/components/kubelet.py
+++ b/src/kube_galaxy/pkg/components/kubelet.py
@@ -4,12 +4,11 @@ Kubelet component installation and management.
 Kubelet is the primary node agent running on each node.
 """
 
-from pathlib import Path
 from typing import ClassVar
 from urllib.request import urlopen
 
 from kube_galaxy.pkg.components import ComponentBase, register_component
-from kube_galaxy.pkg.literals import URLs
+from kube_galaxy.pkg.literals import Commands, URLs
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.shell import run
@@ -48,36 +47,26 @@ class Kubelet(ComponentBase):
         service_url = f"{URLs.K8S_RELEASE_BASE}/cmd/krel/templates/latest/kubelet/kubelet.service"
         with urlopen(service_url) as response:
             service_content = response.read().decode("utf-8")
-
-        # Create systemd directories
-        run(["sudo", "mkdir", "-p", "/usr/lib/systemd/system/kubelet.service.d"], check=True)
-
-        # Write kubelet.service file
-        temp_service = Path(self.component_tmp_dir) / "kubelet.service"
         service_content = service_content.replace("/usr/bin/kubelet", self.install_path)
-        run(["sudo", "mkdir", "-p", str(temp_service.parent)], check=True)
-        run(["sudo", "tee", str(temp_service)], input=service_content, text=True, check=True)
-        run(["sudo", "mkdir", "-p", "/usr/lib/systemd/system"], check=True)
-        run(
-            ["sudo", "cp", str(temp_service), "/usr/lib/systemd/system/kubelet.service"], check=True
-        )
+
+        self.create_systemd_service("kubelet", service_content)
 
     def bootstrap_hook(self) -> None:
         """
         Starts kubelet service and enables it to start on boot.
         """
-        run(["sudo", "systemctl", "daemon-reload"], check=True)
-        run(["sudo", "systemctl", "enable", "--now", "kubelet"], check=True)
+        run(Commands.SYSTEMCTL_DAEMON_RELOAD, check=True)
+        run([*Commands.SYSTEMCTL_ENABLE, "--now", "kubelet"], check=True)
 
     def verify_hook(self) -> None:
         """Verify kubelet is working correctly."""
         # Check kubelet systemctl status
-        run(["systemctl", "is-active", "kubelet"], check=True)
+        run([*Commands.SYSTEMCTL_IS_ACTIVE, "kubelet"], check=True)
 
     def stop_hook(self) -> None:
         """Stop the kubelet service."""
         try:
-            run(["sudo", "systemctl", "stop", "kubelet"], check=False)
+            run([*Commands.SYSTEMCTL_STOP, "kubelet"], check=False)
             info("Stopped kubelet service")
         except Exception as e:
             info(f"Failed to stop kubelet service: {e}")

--- a/src/kube_galaxy/pkg/literals.py
+++ b/src/kube_galaxy/pkg/literals.py
@@ -63,16 +63,21 @@ class Commands:
     """Common shell command patterns."""
 
     # sudo commands
-    SUDO: ClassVar[list[str]] = ["sudo"]
     SUDO_MKDIR_P: ClassVar[list[str]] = ["sudo", "mkdir", "-p"]
     SUDO_CP: ClassVar[list[str]] = ["sudo", "cp"]
     SUDO_RM_RF: ClassVar[list[str]] = ["sudo", "rm", "-rf"]
     SUDO_TEE: ClassVar[list[str]] = ["sudo", "tee"]
     SUDO_CHMOD: ClassVar[list[str]] = ["sudo", "chmod"]
+    SUDO_CHOWN: ClassVar[list[str]] = ["sudo", "chown"]
+
+    # apt commands
+    SUDO_APT_REMOVE: ClassVar[list[str]] = ["sudo", "apt", "remove"]
 
     # systemctl commands
     SYSTEMCTL_DAEMON_RELOAD: ClassVar[list[str]] = ["sudo", "systemctl", "daemon-reload"]
     SYSTEMCTL_ENABLE: ClassVar[list[str]] = ["sudo", "systemctl", "enable"]
+    SYSTEMCTL_DISABLE: ClassVar[list[str]] = ["sudo", "systemctl", "disable"]
+    SYSTEMCTL_IS_ACTIVE: ClassVar[list[str]] = ["sudo", "systemctl", "is-active"]
     SYSTEMCTL_START: ClassVar[list[str]] = ["sudo", "systemctl", "start"]
     SYSTEMCTL_STOP: ClassVar[list[str]] = ["sudo", "systemctl", "stop"]
     SYSTEMCTL_RESTART: ClassVar[list[str]] = ["sudo", "systemctl", "restart"]

--- a/src/kube_galaxy/pkg/utils/components.py
+++ b/src/kube_galaxy/pkg/utils/components.py
@@ -3,6 +3,7 @@ Utilities for component installation and management.
 """
 
 import hashlib
+import shutil
 import tarfile
 import urllib.request
 from pathlib import Path
@@ -70,7 +71,6 @@ def install_binary(
     binary_path: Path,
     binary_name: str,
     component_name: str,
-    dest_dir: Path | None = None,
 ) -> str:
     """
     Install a binary to component directory and register with update-alternatives.
@@ -79,21 +79,18 @@ def install_binary(
         binary_path: Path to the binary
         binary_name: Name of the binary (e.g., 'containerd')
         component_name: Component name for directory structure
-        dest_dir: Optional override destination directory
 
     Raises:
         ComponentError: If installation fails
     """
+    # Use component-specific directory
+    dest_dir = SystemPaths.component_bin_dir(component_name)
     try:
-        # Use component-specific directory if not overridden
-        if dest_dir is None:
-            dest_dir = SystemPaths.component_bin_dir(component_name)
-
         # Create directory and install binary
-        run([*Commands.SUDO_MKDIR_P, str(dest_dir)], check=True)
+        dest_dir.mkdir(parents=True, exist_ok=True)
         dest_path = dest_dir / binary_name
-        run([*Commands.SUDO_CP, str(binary_path), str(dest_path)], check=True)
-        run([*Commands.SUDO_CHMOD, Permissions.EXECUTABLE, str(dest_path)], check=True)
+        shutil.copyfile(binary_path, dest_path)
+        dest_path.chmod(0o755)
 
         # Register with update-alternatives
         alternative_path = f"{SystemPaths.USR_LOCAL_BIN}/{binary_name}"

--- a/tests/unit/components/test_base_utils.py
+++ b/tests/unit/components/test_base_utils.py
@@ -26,19 +26,18 @@ def test_ensure_temp_dir_calls_mkdir(monkeypatch, tmp_path):
     comp = ExampleComponent(
         {}, Manifest(name="m", description="d", kubernetes_version="1.0", nodes=None), make_config()
     )
-
-    called = []
-
-    def fake_run(cmd, **kwargs):
-        called.append(list(cmd))
-
-    monkeypatch.setattr("kube_galaxy.pkg.components._base.run", fake_run)
+    # redirect component temp dir to test tmp_path to avoid /opt writes
+    monkeypatch.setattr(
+        SystemPaths,
+        "component_temp_dir",
+        classmethod(lambda cls, name: Path(tmp_path) / name / "temp"),
+    )
 
     p = Path(comp.component_tmp_dir)
-    # ensure_temp_dir should call sudo mkdir -p with the temp dir
+    # ensure_temp_dir should create the temp dir under tmp_path
     ret = comp.ensure_temp_dir()
     assert str(ret) == str(p)
-    assert any("mkdir" in c for c in (cmd for cmd in called[0]))
+    assert ret.exists()
 
 
 def test_download_binary_from_config_calls_download_file(monkeypatch, tmp_path):
@@ -139,17 +138,25 @@ def test_create_systemd_service_and_write_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr("kube_galaxy.pkg.components._base.run", fake_run)
 
+    # redirect component temp dir to test tmp_path to avoid /opt writes
+    monkeypatch.setattr(
+        SystemPaths,
+        "component_temp_dir",
+        classmethod(lambda cls, name: Path(tmp_path) / name / "temp"),
+    )
+
     service_name = "svc"
     content = "[Unit]\nDescription=svc"
     comp.create_systemd_service(service_name, content, system_location=False)
-    # Expect tee and cp calls recorded
-    assert any("tee" in cmd for cmd in recorded)
+    # Expect copy calls recorded (we use sudo cp now)
     assert any("cp" in cmd for cmd in recorded)
 
     # test write_config_file
     recorded.clear()
     comp.write_config_file("cfg", str(tmp_path / "cfgfile"))
-    assert any("tee" in cmd for cmd in recorded)
+    # Expect copy and chmod recorded for config write
+    assert any("cp" in cmd for cmd in recorded)
+    assert any("chmod" in cmd for cmd in recorded)
 
 
 def test_remove_directories_and_files_and_remove_installed_binary(monkeypatch, tmp_path):

--- a/tests/unit/components/test_kubeadm.py
+++ b/tests/unit/components/test_kubeadm.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 import yaml
 
 from kube_galaxy.pkg.components.kubeadm import Kubeadm
+from kube_galaxy.pkg.literals import SystemPaths
 from kube_galaxy.pkg.manifest.models import (
     ComponentConfig,
     InstallConfig,
@@ -16,7 +19,7 @@ class FakeCompleted:
         self.stdout = stdout
 
 
-def test_kubeadm_configure_writes_cluster_config(monkeypatch):
+def test_kubeadm_configure_writes_cluster_config(monkeypatch, tmp_path):
     # Build manifest with networking
     net = NetworkConfig(name="default", service_cidr="10.96.0.0/12", pod_cidr="192.168.0.0/16")
     manifest = Manifest(
@@ -75,6 +78,13 @@ def test_kubeadm_configure_writes_cluster_config(monkeypatch):
     # Patch both the module-local run and the base module run used by utility methods
     monkeypatch.setattr("kube_galaxy.pkg.components.kubeadm.run", fake_run)
     monkeypatch.setattr("kube_galaxy.pkg.components._base.run", fake_run)
+
+    # redirect component temp dir to test tmp_path to avoid /opt writes
+    monkeypatch.setattr(
+        SystemPaths,
+        "component_temp_dir",
+        classmethod(lambda cls, name: Path(tmp_path) / name / "temp"),
+    )
 
     comp.configure_hook()
 

--- a/tests/unit/components/test_kubelet.py
+++ b/tests/unit/components/test_kubelet.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from kube_galaxy.pkg.components.kubelet import Kubelet
+from kube_galaxy.pkg.literals import SystemPaths
 from kube_galaxy.pkg.manifest.models import (
     ComponentConfig,
     InstallConfig,
@@ -53,10 +54,19 @@ def test_kubelet_configure_calls_urlopen_and_tee(monkeypatch, tmp_path):
         lambda url: ExampleResp(b"ExecStart=/usr/bin/kubelet\n"),
     )
     monkeypatch.setattr("kube_galaxy.pkg.components.kubelet.run", fake_run)
+    # Patch the base module run used by create_systemd_service
+    monkeypatch.setattr("kube_galaxy.pkg.components._base.run", fake_run)
+
+    # redirect component temp dir to test tmp_path to avoid /opt writes
+    monkeypatch.setattr(
+        SystemPaths,
+        "component_temp_dir",
+        classmethod(lambda cls, name: Path(tmp_path) / name / "temp"),
+    )
 
     # Call configure hook
     comp.configure_hook()
 
-    # Expect tee to be called to write temp service file
+    # Expect cp to be called to copy temp service file to system location
     temp_service = Path(comp.component_tmp_dir) / "kubelet.service"
-    assert any(cmd[:2] == ["sudo", "tee"] and str(temp_service) in cmd for cmd in calls)
+    assert any(cmd[:2] == ["sudo", "cp"] and str(temp_service) in cmd for cmd in calls)


### PR DESCRIPTION
This pull request aims to reduce sudo usage and exec calls throughout the kube-galaxy codebase by replacing explicit shell command invocations with Python native operations (like Path.mkdir(), Path.write_text(), shutil.copyfile()) and consolidating command patterns into the Commands class constants.

Changes:

* Refactored file operations to use Python native methods instead of sudo commands where possible (mkdir, write_text, chmod)
* Consolidated shell commands into Commands class constants (SUDO_APT_REMOVE, SYSTEMCTL_DISABLE, SYSTEMCTL_IS_ACTIVE, UPDATE_ALTERNATIVES_REMOVE)
* Updated test files to redirect component temp directories to test tmp_path to avoid /opt writes during testing
* Removed dest_dir parameter from install_binary() function
* Updated README.md with installation instructions
