### PR TITLE
Parallelize image pulls and install

### DIFF
--- a/src/kube_galaxy/pkg/components/containerd.py
+++ b/src/kube_galaxy/pkg/components/containerd.py
@@ -6,6 +6,7 @@ Containerd is the container runtime used by Kubernetes clusters.
 
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from kube_galaxy.pkg.components import ClusterComponentBase, ComponentBase, register_component
@@ -14,6 +15,63 @@ from kube_galaxy.pkg.manifest.models import InstallMethod
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.shell import run
+
+
+def _image_pull_and_retag(cluster_manager: ClusterComponentBase, image: ComponentBase) -> None:
+    """
+    Pull a container image with containerd and retag for use in the cluster.
+
+    Args:
+        cluster_manager: Cluster manager component instance defining image list
+        image: Component instance with CONTAINER_IMAGE method to pull
+    """
+    # Use ctr to pull images directly into containerd
+    to_pull = f"{image.image_repository}:{image.image_tag}"
+    info(f"    Pulling image: {to_pull}")
+    run([*Commands.SUDO_CTR_IMAGES, "pull", to_pull], check=True, stdout=subprocess.DEVNULL)
+    if to_tag := cluster_manager.find_image_retag(to_pull):
+        info(f"    Retag pulled image: {to_pull} -> {to_tag}")
+        run([*Commands.SUDO_CTR_IMAGES, "tag", to_pull, to_tag], check=True)
+    else:
+        info(f"    No retag found for image: {to_pull}")
+
+
+def _image_import_and_retag(cluster_manager: ClusterComponentBase, image: ComponentBase) -> None:
+    """
+    Import a container image archive with containerd and retag for use in the cluster.
+
+    Args:
+        cluster_manager: Cluster manager component instance defining image list
+        image: Component instance with CONTAINER_IMAGE_ARCHIVE method to import
+    """
+    # Use ctr to import images directly into containerd
+
+    if not image.extracted_dir:
+        raise ComponentError(
+            f"Image archive for {image.config.name} not extracted. Run download hook first."
+        )
+
+    tar_archive = str(image.extracted_dir / "image.tar")
+    before = run(
+        [*Commands.SUDO_CTR_IMAGES, "list", "--quiet"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    run([*Commands.SUDO_CTR_IMAGES, "import", tar_archive], check=True)
+    after = run(
+        [*Commands.SUDO_CTR_IMAGES, "list", "--quiet"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    new_images = set(after.stdout.splitlines()) - set(before.stdout.splitlines())
+    for img in new_images:
+        if to_tag := cluster_manager.find_image_retag(img):
+            info(f"    Retag imported image: {img} -> {to_tag}")
+            run([*Commands.SUDO_CTR_IMAGES, "tag", img, to_tag], check=True)
+        else:
+            info(f"    No retag found for imported image: {img}")
 
 
 @register_component("containerd")
@@ -26,9 +84,9 @@ class Containerd(ComponentBase):
     """
 
     # Timeout configuration (in seconds)
-    SOCKET_PATH = Path("/run/containerd/containerd.sock")
-
     BIN_PATH = "bin/*"  # Path inside archive where containerd binary is located
+    MAX_IMAGE_PULL_WORKERS = 10
+    SOCKET_PATH = Path("/run/containerd/containerd.sock")
 
     def _get_pause_image(self) -> str:
         """
@@ -67,65 +125,6 @@ class Containerd(ComponentBase):
                 case InstallMethod.CONTAINER_IMAGE_ARCHIVE:
                     image_archives.append(comp)
         return tagged_images, image_archives
-
-    def _image_pull_and_retag(
-        self, cluster_manager: ClusterComponentBase, image: ComponentBase
-    ) -> None:
-        """
-        Pull a container image with containerd and retag for use in the cluster.
-
-        Args:
-            cluster_manager: Cluster manager component instance defining image list
-            image: Component instance with CONTAINER_IMAGE method to pull
-        """
-        # Use ctr to pull images directly into containerd
-        to_pull = f"{image.image_repository}:{image.image_tag}"
-        info(f"    Pulling image: {to_pull}")
-        run([*Commands.SUDO_CTR_IMAGES, "pull", to_pull], check=True, stdout=subprocess.DEVNULL)
-        if to_tag := cluster_manager.find_image_retag(to_pull):
-            info(f"    Retag pulled image: {to_pull} -> {to_tag}")
-            run([*Commands.SUDO_CTR_IMAGES, "tag", to_pull, to_tag], check=True)
-        else:
-            info(f"    No retag found for image: {to_pull}")
-
-    def _image_import_and_retag(
-        self, cluster_manager: ClusterComponentBase, image: ComponentBase
-    ) -> None:
-        """
-        Import a container image archive with containerd and retag for use in the cluster.
-
-        Args:
-            cluster_manager: Cluster manager component instance defining image list
-            image: Component instance with CONTAINER_IMAGE_ARCHIVE method to import
-        """
-        # Use ctr to import images directly into containerd
-
-        if not image.extracted_dir:
-            raise ComponentError(
-                f"Image archive for {image.config.name} not extracted. Run download hook first."
-            )
-
-        tar_archive = str(image.extracted_dir / "image.tar")
-        before = run(
-            [*Commands.SUDO_CTR_IMAGES, "list", "--quiet"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        run([*Commands.SUDO_CTR_IMAGES, "import", tar_archive], check=True)
-        after = run(
-            [*Commands.SUDO_CTR_IMAGES, "list", "--quiet"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        new_images = set(after.stdout.splitlines()) - set(before.stdout.splitlines())
-        for img in new_images:
-            if to_tag := cluster_manager.find_image_retag(img):
-                info(f"    Retag imported image: {img} -> {to_tag}")
-                run([*Commands.SUDO_CTR_IMAGES, "tag", img, to_tag], check=True)
-            else:
-                info(f"    No retag found for imported image: {img}")
 
     def pre_install_hook(self) -> None:
         """Remove any existing containerd installation to avoid conflicts."""
@@ -203,12 +202,25 @@ WantedBy=multi-user.target
 
         images_tagged, image_archives = self._image_comps_by_type()
         cluster_manager = self.get_cluster_manager()
-        for image in images_tagged:
-            info(f"  Pull and retag image from {image.config.name} component")
-            self._image_pull_and_retag(cluster_manager, image)
-        for image in image_archives:
-            info(f"  Import image archive from {image.config.name} component")
-            self._image_import_and_retag(cluster_manager, image)
+
+        with ThreadPoolExecutor(max_workers=self.MAX_IMAGE_PULL_WORKERS) as executor:
+            # Pull and retag images in parallel
+            pull_futures = []
+            for image in images_tagged:
+                info(f"  Pull and retag image from {image.config.name} component")
+                future = executor.submit(_image_pull_and_retag, cluster_manager, image)
+                pull_futures.append(future)
+
+            # Import and retag image archives in parallel
+            import_futures = []
+            for image in image_archives:
+                info(f"  Import image archive from {image.config.name} component")
+                future = executor.submit(_image_import_and_retag, cluster_manager, image)
+                import_futures.append(future)
+
+            # Wait for all operations to complete
+            for future in pull_futures + import_futures:
+                future.result()  # This will raise any exceptions that occurred
 
     def verify_hook(self) -> None:
         """


### PR DESCRIPTION
This pull request refactors the `containerd` component to improve image handling efficiency and code organization. The main changes include moving image pull/import functions out of the class, reordering the class definition, and parallelizing image operations during bootstrap for faster execution.

Refactor and code organization:

* Moved `_image_pull_and_retag` and `_image_import_and_retag` functions out of the `Containerd` class to module-level, simplifying the class and improving separation of concerns. [[1]](diffhunk://#diff-719aa6d1e905ec424404e25d42b9b3ccc181fe407009b1267e99d58b03b1cc91L19-R20) [[2]](diffhunk://#diff-719aa6d1e905ec424404e25d42b9b3ccc181fe407009b1267e99d58b03b1cc91L91-R39)
* Reordered the definition of the `Containerd` class to follow the module-level functions, making the file structure clearer.

Performance improvements:

* Introduced `ThreadPoolExecutor` in `bootstrap_hook` to parallelize image pull and import operations, significantly speeding up the bootstrap process. [[1]](diffhunk://#diff-719aa6d1e905ec424404e25d42b9b3ccc181fe407009b1267e99d58b03b1cc91R9) [[2]](diffhunk://#diff-719aa6d1e905ec424404e25d42b9b3ccc181fe407009b1267e99d58b03b1cc91R205-R223)
* Added `MAX_IMAGE_PULL_WORKERS` configuration to control the number of parallel workers for image operations.

These changes collectively streamline the code and improve the efficiency of container image setup in the cluster.