### PR TITLE
Update various github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Astral UV
         uses: astral-sh/setup-uv@v7.2.1

--- a/.github/workflows/test-baseline-clusters.yml
+++ b/.github/workflows/test-baseline-clusters.yml
@@ -45,7 +45,7 @@ jobs:
       manifests: ${{ steps.discover.outputs.manifests }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Astral UV
         uses: astral-sh/setup-uv@v7.2.1
@@ -117,7 +117,7 @@ jobs:
           python-version: "3.12"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ">=1.22"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Astral UV
         uses: astral-sh/setup-uv@v7.2.1


### PR DESCRIPTION
This pull request updates the versions of several GitHub Actions used in our workflow configuration files to ensure we are using the latest features and security patches. The main changes are version bumps for the `actions/checkout` and `actions/setup-go` actions across multiple workflow files.

**GitHub Actions version updates:**

* Updated `actions/checkout` from version `v4` to `v6` in `.github/workflows/lint.yml`, `.github/workflows/test.yml`, and `.github/workflows/test-baseline-clusters.yml` to use the latest version with improved performance and security. [[1]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L35-R35) [[2]](diffhunk://#diff-9e7847336df93c9ca0e368a06770fa5634c5a61fe1e3933b3cf306c5e5cff770L48-R48) [[3]](diffhunk://#diff-9e7847336df93c9ca0e368a06770fa5634c5a61fe1e3933b3cf306c5e5cff770L112-R120) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L30-R30)
* Updated `actions/setup-go` from version `v5` to `v6` in `.github/workflows/test-baseline-clusters.yml` for better compatibility and the latest updates.