### PR TITLE
Update upload-artifact github actions to v7

### DIFF
--- a/.github/workflows/test-baseline-clusters.yml
+++ b/.github/workflows/test-baseline-clusters.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ steps.setup-cluster.outputs.artifact-name }}
           path: logs/
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload Debug Logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug-logs-${{ steps.setup-cluster.outputs.artifact-name || hashFiles(matrix.manifest-file) }}
           path: debug-logs/


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for baseline cluster tests to use a newer version of the `upload-artifact` action. This ensures improved reliability and support for artifact uploads during CI runs.

Workflow action version upgrades:

* Updated the `Upload Test Results` step to use `actions/upload-artifact@v7` instead of `@v4` in `.github/workflows/test-baseline-clusters.yml`.
* Updated the `Upload Debug Logs` step to use `actions/upload-artifact@v7` instead of `@v4` in `.github/workflows/test-baseline-clusters.yml`.