### PR TITLE
Add skopeo and spread to prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ custom-built Kubernetes components using the canonical
 - Python 3.12+ with `uv` or `pip`
 - Git
 - skopeo
+- spread
 
 ### Development Setup
 


### PR DESCRIPTION
Run into this error: 
```
ClusterError: Cluster setup failed: Registry mirror prerequisite not met: 'skopeo' not found
```
Had to add:
```
$ sudo apt-get -y install skopeo
```

Also spread was needed:
```
$ kube-galaxy status

Kubernetes Galaxy Test - Project Status
=======================================

Dependencies:
  spread: ❌ not installed
```
Had to snap install it.
