### PR TITLE
Unify dependency checks to print when required tools are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ custom-built Kubernetes components using the canonical
 
 - Python 3.12+ with `uv` or `pip`
 - Git
+- spread (`go install github.com/canonical/spread/cmd/spread@latest`)
+- docker
+- skopeo
+- lxc, multipass, or ssh
+- kubectl
 
 ### Development Setup
 
@@ -129,8 +134,7 @@ kube-galaxy validate --manifest manifests/smoketest.yaml
 kube-galaxy setup manifests/smoketest.yaml
 
 # Verify control plane is running
-kubectl get pods -n kube-system
-kubectl get nodes  # Will show NotReady status
+kube-galaxy logs manifests/smoketest.yaml
 
 # Clean up
 kube-galaxy cleanup all

--- a/src/kube_galaxy/cmd/status.py
+++ b/src/kube_galaxy/cmd/status.py
@@ -1,6 +1,5 @@
 """Status command handler."""
 
-import shutil
 from collections.abc import Callable
 from functools import partial
 
@@ -19,8 +18,8 @@ from kube_galaxy.pkg.utils.client import (
     wait_for_pods,
 )
 from kube_galaxy.pkg.utils.errors import ClusterError
-from kube_galaxy.pkg.utils.logging import error, info, print_dict, section, success, warning
-from kube_galaxy.pkg.utils.shell import run
+from kube_galaxy.pkg.utils.logging import error, info, section, success, warning
+from kube_galaxy.pkg.utils.shell import check_installed, check_version
 
 
 def status(manifest_path: str, wait: bool = False, timeout: int = 300) -> None:
@@ -45,10 +44,8 @@ def status(manifest_path: str, wait: bool = False, timeout: int = 300) -> None:
 def _print_dependency_status() -> None:
     """Print required command dependency status."""
     info("Dependencies:")
-    deps = {
-        "spread": _check_command("spread"),
-    }
-    print_dict(deps)
+    check_installed("spread")
+    check_version("kubectl")
 
 
 def _print_active_manifest(active: str) -> None:
@@ -61,10 +58,6 @@ def _print_active_manifest(active: str) -> None:
 
 def _print_cluster_context(unit: Unit) -> None:
     """Print active cluster context and current node table if available."""
-    if not shutil.which("kubectl"):
-        warning("kubectl not available; skipping cluster checks")
-        return
-
     info("")
     try:
         context = get_context(unit)
@@ -82,9 +75,6 @@ def _print_cluster_context(unit: Unit) -> None:
 
 def _verify_cluster_health(unit: Unit, timeout: int) -> None:
     """Wait for cluster readiness and print summary tables."""
-    if not shutil.which("kubectl"):
-        error("kubectl is required for --wait health checks", show_traceback=False)
-        raise typer.Exit(code=1)
 
     section("Cluster Health Verification")
     info("Waiting for nodes to be Ready...")
@@ -112,31 +102,3 @@ def _print_command_output(command: Callable[[], str], title: str) -> None:
     except ClusterError as exc:
         error(f"Failed to run: {title}", show_traceback=False)
         raise typer.Exit(code=1) from exc
-
-
-def _check_command(cmd: str) -> str:
-    """Check if a command is installed and return status."""
-    if shutil.which(cmd):
-        try:
-            if cmd == "kubectl":
-                result = run(
-                    [cmd, "version", "--client"],
-                    capture_output=True,
-                    check=False,
-                )
-            else:
-                result = run(
-                    [cmd, "--version"],
-                    capture_output=True,
-                    check=False,
-                )
-
-            if result.returncode == 0:
-                version = result.stdout.strip().split("\n")[0]
-                return f"✅ {version}"
-            else:
-                return "⚠️  installed (version check failed)"
-        except Exception:
-            return "⚠️  installed (version check error)"
-    else:
-        return "❌ not installed"

--- a/src/kube_galaxy/pkg/components/kubeadm.py
+++ b/src/kube_galaxy/pkg/components/kubeadm.py
@@ -5,7 +5,6 @@ Kubeadm is used to bootstrap Kubernetes clusters.
 """
 
 import shlex
-import shutil
 from pathlib import Path
 from typing import Any
 from urllib.request import urlopen
@@ -189,10 +188,6 @@ class Kubeadm(ClusterComponentBase):
         This performs a kubeadm reset to cleanly shut down the cluster,
         removing the node from the cluster and cleaning up cluster state.
         """
-        if not shutil.which("kubeadm"):
-            info("kubeadm not found in PATH, skipping cluster reset")
-            return
-
         info("Performing kubeadm reset to stop cluster")
         self.unit.run(["kubeadm", "reset", "--force"], privileged=True)
         info("Kubeadm reset completed successfully")

--- a/src/kube_galaxy/pkg/testing/spread.py
+++ b/src/kube_galaxy/pkg/testing/spread.py
@@ -17,7 +17,7 @@ from kube_galaxy.pkg.units.local import LocalUnit
 from kube_galaxy.pkg.utils.errors import ClusterError
 from kube_galaxy.pkg.utils.logging import error, info, section, success, warning
 from kube_galaxy.pkg.utils.paths import ensure_dir
-from kube_galaxy.pkg.utils.shell import ShellError, run
+from kube_galaxy.pkg.utils.shell import ShellError, check_installed
 
 
 def _TeeRun(cmd: list[str], cwd: Path, env: dict[str, str], log_file: Path) -> int:
@@ -82,7 +82,7 @@ def run_spread_tests(
         info(f"Work Dir: {work_dir}")
 
         # Verify test prerequisites (kubectl connectivity, spread availability)
-        _verify_test_prerequisites()
+        _print_dependency_status()
 
         # Run tests from components with spread enabled
         _run_component_tests(manifest, work_dir_path, test_type, debug)
@@ -94,20 +94,16 @@ def run_spread_tests(
         raise ClusterError(f"Test execution failed: {exc}") from exc
 
 
-def _verify_test_prerequisites() -> None:
+def _print_dependency_status() -> None:
     """Verify spread is available."""
     try:
         # Check for spread
         info("Verifying spread test framework...")
-        result = run(["which", "spread"], check=True, capture_output=True)
-        spread_path = result.stdout.strip()
-        success(f"Found spread at {spread_path}")
+        check_installed("spread")
 
         # Check for lxclient (required by spread)
         info("Verifying lxclient (required by spread)...")
-        result = run(["which", "lxc"], check=True, capture_output=True)
-        lxclient_path = result.stdout.strip()
-        success(f"Found lxclient at {lxclient_path}")
+        check_installed("lxc")
 
     except ShellError as exc:
         raise ClusterError("Test prerequisites not met") from exc

--- a/src/kube_galaxy/pkg/units/lxdvm.py
+++ b/src/kube_galaxy/pkg/units/lxdvm.py
@@ -12,7 +12,20 @@ from kube_galaxy.pkg.units._base import RunResult, Unit, UnitProvider
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.paths import ensure_dir
-from kube_galaxy.pkg.utils.shell import ShellError
+from kube_galaxy.pkg.utils.shell import ShellError, check_version
+
+
+def _print_dependency_status() -> None:
+    """Verify that ``lxc`` is available.
+
+    Raises:
+        ComponentError: If ``lxc`` is not found.
+    """
+    try:
+        info("Verifying lxc...")
+        check_version("lxc")
+    except ShellError as exc:
+        raise ComponentError("LXDUnit prerequisite not met: 'lxc' not found") from exc
 
 
 class LXDUnit(Unit):
@@ -110,6 +123,7 @@ class LXDUnitProvider(UnitProvider):
 
     def __init__(self, image: str = "ubuntu:24.04") -> None:
         super().__init__()
+        _print_dependency_status()
         self._image = image
 
     @property

--- a/src/kube_galaxy/pkg/units/multipass.py
+++ b/src/kube_galaxy/pkg/units/multipass.py
@@ -8,7 +8,20 @@ from kube_galaxy.pkg.units._base import RunResult, Unit, UnitProvider
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.paths import ensure_dir
-from kube_galaxy.pkg.utils.shell import ShellError
+from kube_galaxy.pkg.utils.shell import ShellError, check_version
+
+
+def _print_dependency_status() -> None:
+    """Verify that ``multipass`` is available.
+
+    Raises:
+        ComponentError: If ``multipass`` is not found.
+    """
+    try:
+        info("Verifying multipass...")
+        check_version("multipass")
+    except ShellError as exc:
+        raise ComponentError("MultipassUnit prerequisite not met: 'multipass' not found") from exc
 
 
 class MultipassUnit(Unit):
@@ -94,6 +107,7 @@ class MultipassUnitProvider(UnitProvider):
 
     def __init__(self, image: str = "ubuntu:24.04") -> None:
         super().__init__()
+        _print_dependency_status()
         self._image = image
 
     @property

--- a/src/kube_galaxy/pkg/units/ssh.py
+++ b/src/kube_galaxy/pkg/units/ssh.py
@@ -8,7 +8,22 @@ from kube_galaxy.pkg.units._base import RunResult, Unit, UnitProvider
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.paths import ensure_dir
-from kube_galaxy.pkg.utils.shell import ShellError
+from kube_galaxy.pkg.utils.shell import ShellError, check_installed, check_version
+
+
+def _print_dependency_status() -> None:
+    """Verify that ``ssh`` and ``scp`` are available.
+
+    Raises:
+        ComponentError: If either ``ssh`` or ``scp`` is not found.
+    """
+    try:
+        check_version("ssh")
+        check_installed("scp")
+    except ShellError as exc:
+        raise ComponentError(
+            "SSHUnit prerequisites not met: 'ssh' and 'scp' must be installed"
+        ) from exc
 
 
 class SSHUnit(Unit):
@@ -97,6 +112,7 @@ class SSHUnitProvider(UnitProvider):
 
     def __init__(self, hosts: list[str]) -> None:
         super().__init__()
+        _print_dependency_status()
         self._hosts = hosts
 
     @property

--- a/src/kube_galaxy/pkg/utils/logs.py
+++ b/src/kube_galaxy/pkg/utils/logs.py
@@ -17,6 +17,13 @@ from kube_galaxy.pkg.utils.client import (
 from kube_galaxy.pkg.utils.errors import ClusterError
 from kube_galaxy.pkg.utils.logging import info, section, success, warning
 from kube_galaxy.pkg.utils.paths import ensure_dir
+from kube_galaxy.pkg.utils.shell import check_version
+
+
+def _print_dependency_status() -> None:
+    """Print required command dependency status."""
+    info("Dependencies:")
+    check_version("kubectl")
 
 
 def collect_kubernetes_logs(unit: Unit) -> str:
@@ -32,6 +39,7 @@ def collect_kubernetes_logs(unit: Unit) -> str:
     Raises:
         ClusterError: If log collection fails
     """
+    _print_dependency_status()
     output_path = Path(TestDirectories.DEBUG_LOGS)
     ensure_dir(output_path)
 

--- a/src/kube_galaxy/pkg/utils/registry_mirror.py
+++ b/src/kube_galaxy/pkg/utils/registry_mirror.py
@@ -25,7 +25,7 @@ from kube_galaxy.pkg.manifest.models import RegistryConfig
 from kube_galaxy.pkg.utils import shell
 from kube_galaxy.pkg.utils.detector import detect_ip
 from kube_galaxy.pkg.utils.errors import ClusterError
-from kube_galaxy.pkg.utils.logging import info, success
+from kube_galaxy.pkg.utils.logging import info
 from kube_galaxy.pkg.utils.shell import ShellError
 
 _CONTAINER_NAME = "registry-cache"
@@ -33,7 +33,7 @@ _REGISTRY_IMAGE = "registry:3"
 _REQUIRED_TOOLS = ("docker", "skopeo")
 
 
-def verify_prerequisites() -> None:
+def _print_dependency_status() -> None:
     """Verify that ``docker`` and ``skopeo`` are available on PATH.
 
     Raises:
@@ -42,8 +42,7 @@ def verify_prerequisites() -> None:
     for tool in _REQUIRED_TOOLS:
         try:
             info(f"Verifying {tool}...")
-            result = shell.run(["which", tool], check=True, capture_output=True)
-            success(f"Found {tool} at {result.stdout.strip()}")
+            shell.check_version(tool)
         except ShellError as exc:
             raise ClusterError(f"Registry mirror prerequisite not met: '{tool}' not found") from exc
 
@@ -84,7 +83,7 @@ class RegistryMirror:
         Creates :attr:`data_dir` if it does not already exist, then launches
         the Docker container in the background.
         """
-        verify_prerequisites()
+        _print_dependency_status()
         self.data_dir.mkdir(parents=True, exist_ok=True)
         shell.run(
             [

--- a/src/kube_galaxy/pkg/utils/shell.py
+++ b/src/kube_galaxy/pkg/utils/shell.py
@@ -1,7 +1,10 @@
 """Shell subprocess execution wrapper."""
 
+import shutil
 import subprocess
 from typing import Any
+
+from kube_galaxy.pkg.utils.logging import success, warning
 
 
 class ShellError(Exception):
@@ -49,3 +52,42 @@ def run(
         raise ShellError(command, result.returncode, stderr)
 
     return result
+
+
+def check_installed(cmd: str) -> None:
+    """Check if a command is installed and return status."""
+    if not shutil.which(cmd):
+        raise ShellError([cmd], 1, f"❌ {cmd} not installed")
+    success(f"{cmd} is installed")
+
+
+def check_version(cmd: str) -> None:
+    """Check if a command is installed and return its version."""
+    check_installed(cmd)
+    try:
+        if cmd == "kubectl":
+            result = run(
+                [cmd, "version", "--client"],
+                capture_output=True,
+                check=False,
+            )
+        if cmd == "ssh":
+            result = run(
+                [cmd, "-V"],
+                capture_output=True,
+                check=False,
+            )
+        else:
+            result = run(
+                [cmd, "--version"],
+                capture_output=True,
+                check=False,
+            )
+
+        if result.returncode == 0:
+            version = result.stdout.strip().split("\n")[0]
+            success(f"{cmd} version: {version}")
+        else:
+            warning(f"{cmd} version check failed: {result.stderr.strip()}")
+    except Exception:
+        warning(f"{cmd} version check error")

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -52,7 +52,8 @@ def test_provider_factory_lxd():
     assert p.is_ephemeral
 
 
-def test_provider_factory_multipass():
+def test_provider_factory_multipass(monkeypatch):
+    monkeypatch.setattr("kube_galaxy.pkg.units.multipass.check_version", lambda _cmd: None)
     m = _manifest_with_provider("multipass", image="ubuntu:24.04")
     p = provider_factory(m)
     assert isinstance(p, MultipassUnitProvider)
@@ -140,14 +141,16 @@ def test_lxd_provider_locate_populates_units_for_deprovision_all(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_multipass_provider_locate_deterministic_name():
+def test_multipass_provider_locate_deterministic_name(monkeypatch):
+    monkeypatch.setattr("kube_galaxy.pkg.units.multipass.check_version", lambda _cmd: None)
     p = MultipassUnitProvider(image="ubuntu:24.04")
     u = p.locate(NodeRole.WORKER, 1)
     assert isinstance(u, MultipassUnit)
     assert u.name == "kube-galaxy-worker-1"
 
 
-def test_multipass_provider_locate_dedup():
+def test_multipass_provider_locate_dedup(monkeypatch):
+    monkeypatch.setattr("kube_galaxy.pkg.units.multipass.check_version", lambda _cmd: None)
     p = MultipassUnitProvider(image="ubuntu:24.04")
     p.locate(NodeRole.WORKER, 0)
     p.locate(NodeRole.WORKER, 0)

--- a/tests/unit/test_registry_mirror.py
+++ b/tests/unit/test_registry_mirror.py
@@ -10,8 +10,7 @@ import kube_galaxy.pkg.utils.registry_mirror as mirror_mod
 from kube_galaxy.pkg.literals import SystemPaths, URLs
 from kube_galaxy.pkg.manifest.models import RegistryConfig
 from kube_galaxy.pkg.utils.errors import ClusterError
-from kube_galaxy.pkg.utils.registry_mirror import RegistryMirror, verify_prerequisites
-from kube_galaxy.pkg.utils.shell import ShellError
+from kube_galaxy.pkg.utils.registry_mirror import RegistryMirror, _print_dependency_status
 
 _FAKE_IP = "10.0.0.1"
 
@@ -29,54 +28,55 @@ def _noop_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[s
 
 
 # ---------------------------------------------------------------------------
-# verify_prerequisites
+# _print_dependency_status
 # ---------------------------------------------------------------------------
 
 
 class TestVerifyPrerequisites:
     def test_passes_when_both_tools_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """verify_prerequisites() succeeds when docker and skopeo are on PATH."""
+        """_print_dependency_status() succeeds when docker and skopeo are on PATH."""
 
         def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
             return subprocess.CompletedProcess(cmd, 0, stdout=f"/usr/bin/{cmd[1]}", stderr="")
 
         monkeypatch.setattr(mirror_mod.shell, "run", fake_run)
-        verify_prerequisites()  # must not raise
+        _print_dependency_status()  # must not raise
 
     def test_raises_cluster_error_when_docker_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """verify_prerequisites() raises ClusterError when docker is absent."""
+        """_print_dependency_status() raises ClusterError when docker is absent."""
 
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-            if cmd[1] == "docker":
-                raise ShellError(cmd, 1, "not found")
-            return subprocess.CompletedProcess(cmd, 0, stdout=f"/usr/bin/{cmd[1]}", stderr="")
+        def fake_which(cmd: str) -> str | None:
+            if cmd == "docker":
+                return None
+            return f"/usr/bin/{cmd}"
 
-        monkeypatch.setattr(mirror_mod.shell, "run", fake_run)
+        monkeypatch.setattr(mirror_mod.shell.shutil, "which", fake_which)
         with pytest.raises(ClusterError, match="docker"):
-            verify_prerequisites()
+            _print_dependency_status()
 
     def test_raises_cluster_error_when_skopeo_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """verify_prerequisites() raises ClusterError when skopeo is absent."""
+        """_print_dependency_status() raises ClusterError when skopeo is absent."""
 
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-            if cmd[1] == "skopeo":
-                raise ShellError(cmd, 1, "not found")
-            return subprocess.CompletedProcess(cmd, 0, stdout=f"/usr/bin/{cmd[1]}", stderr="")
+        def fake_which(cmd: str) -> str | None:
+            if cmd == "skopeo":
+                return None
+            return f"/usr/bin/{cmd}"
 
-        monkeypatch.setattr(mirror_mod.shell, "run", fake_run)
+        monkeypatch.setattr(mirror_mod.shell.shutil, "which", fake_which)
+        monkeypatch.setattr(mirror_mod.shell, "run", _noop_run)
         with pytest.raises(ClusterError, match="skopeo"):
-            verify_prerequisites()
+            _print_dependency_status()
 
-    def test_start_calls_verify_prerequisites(
+    def test_start_calls_print_dependency_status(
         self, patched_env: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """start() delegates to verify_prerequisites before launching docker."""
+        """start() delegates to _print_dependency_status before launching docker."""
         verified: list[bool] = []
-        monkeypatch.setattr(mirror_mod, "verify_prerequisites", lambda: verified.append(True))
+        monkeypatch.setattr(mirror_mod, "_print_dependency_status", lambda: verified.append(True))
         monkeypatch.setattr(mirror_mod.shell, "run", _noop_run)
         RegistryMirror(RegistryConfig()).start()
         assert verified == [True]

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -34,8 +34,8 @@ def test_status_wait_runs_readiness_checks(monkeypatch):
     monkeypatch.setattr(status_cmd, "get_nodes", fake_get_nodes)
     monkeypatch.setattr(status_cmd, "get_cluster_info", lambda _unit: "cluster-info")
     monkeypatch.setattr(status_cmd, "get_pods", lambda _unit: "pods-output")
-    monkeypatch.setattr(status_cmd, "_check_command", lambda _cmd: "ok")
-    monkeypatch.setattr(status_cmd.shutil, "which", lambda _cmd: "/usr/bin/tool")
+    monkeypatch.setattr(status_cmd, "check_installed", lambda _cmd: None)
+    monkeypatch.setattr(status_cmd, "check_version", lambda _cmd: None)
     monkeypatch.setattr(
         status_cmd,
         "load_manifest",
@@ -70,8 +70,8 @@ def test_status_wait_exits_non_zero_on_readiness_failure(monkeypatch):
     monkeypatch.setattr(status_cmd, "wait_for_nodes", fake_wait_for_nodes)
     monkeypatch.setattr(status_cmd, "get_context", fake_get_context)
     monkeypatch.setattr(status_cmd, "get_nodes", fake_get_nodes)
-    monkeypatch.setattr(status_cmd, "_check_command", lambda _cmd: "ok")
-    monkeypatch.setattr(status_cmd.shutil, "which", lambda _cmd: "/usr/bin/tool")
+    monkeypatch.setattr(status_cmd, "check_installed", lambda _cmd: None)
+    monkeypatch.setattr(status_cmd, "check_version", lambda _cmd: None)
     monkeypatch.setattr(
         status_cmd,
         "load_manifest",


### PR DESCRIPTION
This pull request refactors how external command dependencies are checked and reported throughout the codebase, centralizing and standardizing dependency validation logic. It replaces ad-hoc checks and custom implementations with new utility functions, improves dependency reporting, and updates documentation and tests accordingly.

Dependency checking and reporting improvements:

* Introduced new utility functions `check_installed` and `check_version` in `src/kube_galaxy/pkg/utils/shell.py` to standardize how the presence and version of external commands are validated and reported. These replace previous custom logic and direct `shutil.which` checks.
* Refactored multiple modules (`src/kube_galaxy/cmd/status.py`, `src/kube_galaxy/pkg/components/kubeadm.py`, `src/kube_galaxy/pkg/testing/spread.py`, `src/kube_galaxy/pkg/units/lxdvm.py`, `src/kube_galaxy/pkg/units/multipass.py`, `src/kube_galaxy/pkg/units/ssh.py`, `src/kube_galaxy/pkg/utils/logs.py`, `src/kube_galaxy/pkg/utils/registry_mirror.py`) to use these new utility functions for dependency checks, improving consistency and error handling. [[1]](diffhunk://#diff-2161de7d44dc4ad3cb56311fb2b22fe13b5a4c04b85ecfe952b61d9edbad10dbL22-R22) [[2]](diffhunk://#diff-2161de7d44dc4ad3cb56311fb2b22fe13b5a4c04b85ecfe952b61d9edbad10dbL48-R48) [[3]](diffhunk://#diff-2161de7d44dc4ad3cb56311fb2b22fe13b5a4c04b85ecfe952b61d9edbad10dbL64-L67) [[4]](diffhunk://#diff-2161de7d44dc4ad3cb56311fb2b22fe13b5a4c04b85ecfe952b61d9edbad10dbL85-L87) [[5]](diffhunk://#diff-7ba701716aa2bd4629dd7ccebe02c04ae5ec63da22cfb6fc2d36d40a01d84185L192-L195) [[6]](diffhunk://#diff-4413028033c6836f57da086070dc1e39412584e680a9b75c097c2436b301533dL20-R20) [[7]](diffhunk://#diff-4413028033c6836f57da086070dc1e39412584e680a9b75c097c2436b301533dL85-R85) [[8]](diffhunk://#diff-4413028033c6836f57da086070dc1e39412584e680a9b75c097c2436b301533dL97-R106) [[9]](diffhunk://#diff-034eec9a3bd80a29369ed777a2f362e6688d614baa66ff1fab4e472d53fb7ca0L15-R28) [[10]](diffhunk://#diff-034eec9a3bd80a29369ed777a2f362e6688d614baa66ff1fab4e472d53fb7ca0R126) [[11]](diffhunk://#diff-94f61a6b6178753458c4030cc2618d8be91d22a38a1f8ffb510494a400a260d9L11-R24) [[12]](diffhunk://#diff-94f61a6b6178753458c4030cc2618d8be91d22a38a1f8ffb510494a400a260d9R110) [[13]](diffhunk://#diff-a82d7075302745ea78ce11c44f10891be217b93f22c6d07bc68ffb647acb307dL11-R26) [[14]](diffhunk://#diff-a82d7075302745ea78ce11c44f10891be217b93f22c6d07bc68ffb647acb307dR115) [[15]](diffhunk://#diff-8b72a84731539cf9275f99127dc6c01f6a1873fb8c25245cad82ecba9109ec1eR20-R26) [[16]](diffhunk://#diff-8b72a84731539cf9275f99127dc6c01f6a1873fb8c25245cad82ecba9109ec1eR42) [[17]](diffhunk://#diff-9a3c28f89b8ab813a408a094be75ca8b8071cdaadf3f1097e5797a6143532265L28-R36) [[18]](diffhunk://#diff-9a3c28f89b8ab813a408a094be75ca8b8071cdaadf3f1097e5797a6143532265L45-R45) [[19]](diffhunk://#diff-9a3c28f89b8ab813a408a094be75ca8b8071cdaadf3f1097e5797a6143532265L87-R86)

Developer experience and documentation:

* Updated the `README.md` to clarify and expand the list of required development dependencies, including `spread`, `docker`, `skopeo`, `lxc`, `multipass`, `ssh`, and `kubectl`. Also updated usage instructions to reflect changes to log collection commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R137)

Testing updates:

* Updated tests in `tests/unit/test_cluster.py` and `tests/unit/test_registry_mirror.py` to mock new dependency check functions, ensuring tests remain isolated from system dependencies. [[1]](diffhunk://#diff-c37096230d2f06ebee198551d59549c1536ce7fdd0ef3b3a1f5be3ef360a9637L55-R56) [[2]](diffhunk://#diff-c37096230d2f06ebee198551d59549c1536ce7fdd0ef3b3a1f5be3ef360a9637L143-R153) [[3]](diffhunk://#diff-03ac63ce10b49121238270580a4b63fa4cdfad5b867aa9cfdc6168a403e126d2L13-R13)

These changes collectively make dependency management more robust, maintainable, and user-friendly.