### PR TITLE
Create a new provider to enlist juju machines

### DIFF
--- a/src/kube_galaxy/pkg/components/_base.py
+++ b/src/kube_galaxy/pkg/components/_base.py
@@ -5,7 +5,6 @@ All component implementations should inherit from ComponentBase and
 override the lifecycle hooks they need.
 """
 
-import shutil
 from abc import abstractmethod
 from collections.abc import Iterable
 from pathlib import Path
@@ -167,7 +166,7 @@ class ComponentBase:
         hook_method = getattr(self, f"{hook_name}_hook", None)
         if not hook_method:
             raise ComponentError(f"{hook_name_caps} hook not implemented for {self.name}")
-        info(f"  {self.name}: {hook_name_caps} on {self.unit.hostname()}...")
+        info(f"  {self.name}: {hook_name_caps} on {self.unit.hostname}...")
         hook_method()
 
     def download_hook(self) -> None:
@@ -234,16 +233,6 @@ class ComponentBase:
         """
         self._install_strategy.verify(self)
         self._test_strategy.verify(self)
-
-    def remove_hook(self) -> None:
-        """
-        Remove/uninstall the component.
-
-        This hook runs during component removal.
-        Override to implement cleanup logic.
-        """
-        self._install_strategy.remove(self)
-        self._test_strategy.remove(self)
 
     # Component directory and alternatives management methods
     @property
@@ -312,20 +301,13 @@ class ComponentBase:
 
     def delete_hook(self) -> None:
         """
-        Delete component binaries and configuration files.
+        Remove/uninstall the component.
 
-        This hook runs in the DELETE stage of teardown (sequential, reverse dependency order).
-        Override to implement binary/config removal logic.
+        This hook runs during component removal.
+        Override to implement cleanup logic.
         """
-        # Remove update-alternatives entries for this component
-        self.remove_component_alternatives()
-
-        # extracted_dir is a local staging directory — clean it up locally
-        if self.extracted_dir and self.extracted_dir.exists():
-            shutil.rmtree(self.extracted_dir, ignore_errors=True)
-
-        # Remove component directory (binaries) on the unit
-        self.cleanup_component_dir()
+        self._install_strategy.delete(self)
+        self._test_strategy.delete(self)
 
     def post_delete_hook(self) -> None:
         """

--- a/src/kube_galaxy/pkg/components/kubeadm.py
+++ b/src/kube_galaxy/pkg/components/kubeadm.py
@@ -89,7 +89,7 @@ class Kubeadm(ClusterComponentBase):
         control plane settings.
         """
         config["nodeRegistration"]["taints"] = []
-        config["nodeRegistration"]["name"] = self.unit.hostname()
+        config["nodeRegistration"]["name"] = self.unit.hostname
         config["localAPIEndpoint"]["advertiseAddress"] = "0.0.0.0"
 
     def _kubeadm_config(self) -> None:
@@ -187,7 +187,7 @@ class Kubeadm(ClusterComponentBase):
         # token is the full join command returned by kubeadm token create --print-join-command
         # shlex.split() safely parses the command string into a list for subprocess execution
         cmd = shlex.split(token)
-        cmd.append(f"--node-name={self.unit.hostname()}")
+        cmd.append(f"--node-name={self.unit.hostname}")
         if role == NodeRole.CONTROL_PLANE:
             ## TODO: Support multiple control-plane nodes with a VIP
             cmd.append("--control-plane")

--- a/src/kube_galaxy/pkg/components/strategies/_base.py
+++ b/src/kube_galaxy/pkg/components/strategies/_base.py
@@ -45,7 +45,7 @@ class _InstallStrategy:
     configure: Callable[[ComponentBase], None] = _noop
     bootstrap: Callable[[ComponentBase], None] = _noop
     verify: Callable[[ComponentBase], None] = _noop
-    remove: Callable[[ComponentBase], None] = _noop
+    delete: Callable[[ComponentBase], None] = _noop
 
 
 @dataclass
@@ -56,7 +56,7 @@ class _TestStrategy:
     configure: Callable[[ComponentBase], None] = _noop
     bootstrap: Callable[[ComponentBase], None] = _noop
     verify: Callable[[ComponentBase], None] = _noop
-    remove: Callable[[ComponentBase], None] = _noop
+    delete: Callable[[ComponentBase], None] = _noop
 
 
 def only_lead_control_plane(func: CompCallable) -> CompCallable:

--- a/src/kube_galaxy/pkg/components/strategies/binary.py
+++ b/src/kube_galaxy/pkg/components/strategies/binary.py
@@ -22,4 +22,12 @@ def _install(comp: ComponentBase) -> None:
     comp.install_path = comp.install_downloaded_binary(comp.download_path)
 
 
-_BinaryInstallStrategy = _InstallStrategy(download=_download, install=_install)
+def _delete(comp: ComponentBase) -> None:
+    # Remove update-alternatives entries for this component
+    comp.remove_component_alternatives()
+
+    # Remove component directory (binaries) on the unit
+    comp.cleanup_component_dir()
+
+
+_BinaryInstallStrategy = _InstallStrategy(download=_download, install=_install, delete=_delete)

--- a/src/kube_galaxy/pkg/components/strategies/binary_archive.py
+++ b/src/kube_galaxy/pkg/components/strategies/binary_archive.py
@@ -42,4 +42,14 @@ def _install(comp: ComponentBase) -> None:
         comp.install_path = installed[comp.name]
 
 
-_BinaryArchiveInstallStrategy = _InstallStrategy(download=_download, install=_install)
+def _delete(comp: ComponentBase) -> None:
+    # Remove update-alternatives entries for this component
+    comp.remove_component_alternatives()
+
+    # Remove component directory (binaries) on the unit
+    comp.cleanup_component_dir()
+
+
+_BinaryArchiveInstallStrategy = _InstallStrategy(
+    download=_download, install=_install, delete=_delete
+)

--- a/src/kube_galaxy/pkg/manifest/validator.py
+++ b/src/kube_galaxy/pkg/manifest/validator.py
@@ -7,7 +7,7 @@ import yaml
 from kube_galaxy.pkg.literals import SystemPaths
 from kube_galaxy.pkg.manifest.models import ComponentConfig, Manifest, TestMethod
 
-_VALID_PROVIDER_TYPES = {"local", "lxd", "multipass", "ssh"}
+_VALID_PROVIDER_TYPES = {"local", "lxd", "multipass", "ssh", "juju"}
 _VALID_PLACEMENT_VALUES = {"all", "control-plane", "workers", "orchestrator"}
 
 

--- a/src/kube_galaxy/pkg/units/_base.py
+++ b/src/kube_galaxy/pkg/units/_base.py
@@ -56,6 +56,8 @@ class Unit(ABC):
     - ``MultipassUnit``  ``multipass exec`` / ``multipass transfer``; ephemeral
     """
 
+    ENLIST_TIMEOUT = Timeouts.UNIT_READY_TIMEOUT
+
     def __init__(self, role: NodeRole, index: int) -> None:
         self.role = role
         self.index = index
@@ -159,6 +161,7 @@ class Unit(ABC):
         if hosts_path == "/etc/hosts.new":
             self.run(["mv", hosts_path, "/etc/hosts"], privileged=True)
 
+    @cached_property
     def hostname(self) -> str:
         """Return the unit's hostname."""
         result = self.run(["hostname"], check=False)

--- a/src/kube_galaxy/pkg/units/juju.py
+++ b/src/kube_galaxy/pkg/units/juju.py
@@ -1,0 +1,269 @@
+"""JujuUnit executes operations inside a juju machine model
+
+Uses only the ``juju`` CLI
+Juju machines run as root so the ``privileged`` flag is ignored.
+"""
+
+import json
+import shlex
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from kube_galaxy.pkg.literals import Timeouts
+from kube_galaxy.pkg.manifest.models import NodeRole
+from kube_galaxy.pkg.units._base import RunResult, Unit, UnitProvider
+from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
+from kube_galaxy.pkg.utils.logging import info, warning
+from kube_galaxy.pkg.utils.paths import ensure_dir
+from kube_galaxy.pkg.utils.shell import ShellError, check_version, run
+
+
+def print_dependency_status() -> None:
+    """Verify that ``juju`` is available.
+
+    Raises:
+        ComponentError: If ``juju`` is not found.
+    """
+    try:
+        info("Verifying juju...")
+        check_version("juju")
+    except ShellError as exc:
+        raise ComponentError("JujuUnit prerequisite not met: 'juju' not found") from exc
+
+    if not _get_state():
+        raise ComponentError(
+            "JujuUnit prerequisite not met: 'juju status' did not return valid JSON"
+        )
+
+
+def _get_state(name: str = "", timeout: float = 10) -> dict[str, Any]:
+    cmd = f"juju status {name} --format json"
+    result = run(shlex.split(cmd), check=False, capture_output=True, text=True, timeout=timeout)
+    if result.returncode == 0:
+        parsed = None
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            warning(f"Failed to parse juju status output as JSON: {result.stdout}")
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _get_application_status(app: str, timeout: float = 10) -> dict[str, Any]:
+    state = _get_state(app, timeout=timeout)
+    try:
+        apps = state["applications"][app]
+        if isinstance(apps, dict):
+            return apps
+    except KeyError:
+        warning(f"Failed to get status for juju application '{app}': unexpected status format")
+    return {}
+
+
+def _get_unit_status(unit: str, timeout: float = 10) -> dict[str, Any]:
+    state = _get_application_status(unit.split("/")[0], timeout=timeout)
+    try:
+        units = state["units"][unit]
+        if isinstance(units, dict):
+            return units
+    except KeyError:
+        warning(f"Failed to get status for juju unit '{unit}': unexpected status format")
+    return {}
+
+
+def _get_workload_status(unit: str, timeout: float = 10) -> tuple[str, str] | None:
+    if unit_status := _get_unit_status(unit, timeout=timeout):
+        try:
+            workload, juju = (unit_status[_]["current"] for _ in ("workload-status", "juju-status"))
+            return workload, juju
+        except KeyError:
+            warning(
+                f"Failed to get workload status for juju unit '{unit}': unexpected status format"
+            )
+    return None
+
+
+class JujuUnit(Unit):
+    """Unit backed by a Juju machine.
+
+    All commands run as root inside the machine, so ``privileged=True``
+    is silently accepted and has no additional effect.
+    """
+
+    JUJU_PATIENT_TIMEOUT = 900  # Juju machines can be slow to provision and become ready
+
+    def __init__(self, machine_name: str, role: NodeRole, index: int) -> None:
+        super().__init__(role, index)
+        self._name = machine_name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @staticmethod
+    def application(unit: str) -> str:
+        return unit.split("/")[0]
+
+    def _enable_root_ssh(self) -> None:
+        # Juju machines don't have root SSH access by default,
+        # but we can copy the ubuntu user's authorized_keys to root
+        self.run(["sudo", "mkdir", "-p", "/root/.ssh"], check=True)
+        self.run(
+            ["sudo", "cp", "/home/ubuntu/.ssh/authorized_keys", "/root/.ssh/authorized_keys"],
+            check=True,
+        )
+
+    def enlist(self, timeout: float | None = None) -> None:
+        # Juju machines can take a while to come up, so instead we wait for active/idle
+        effective_timeout = self.JUJU_PATIENT_TIMEOUT if timeout is None else timeout
+        deadline = time.monotonic() + effective_timeout
+        while not _get_workload_status(self.name, timeout=10) == ("active", "idle"):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ClusterError(
+                    f"Timed out waiting for unit '{self.name}' to become ready "
+                    f"after {effective_timeout:.0f}s"
+                )
+            time.sleep(min(Timeouts.UNIT_READY_INTERVAL, remaining))
+        self._enable_root_ssh()
+        self.update_etc_hosts()
+
+    def _juju_exec(
+        self,
+        cmd: list[str],
+        *,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> RunResult:
+        """Run a command inside the Juju machine via ``juju exec``."""
+        juju_cmd: list[str] = ["juju", "exec", "--unit", self._name, "--"]
+        if env:
+            for k, v in env.items():
+                juju_cmd.append(f"{k}={v}")
+        juju_cmd.extend(cmd)
+        result = subprocess.run(
+            juju_cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+        if check and result.returncode != 0:
+            raise ShellError(juju_cmd, result.returncode, result.stderr or "")
+        return RunResult(
+            returncode=result.returncode,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+        privileged: bool = False,
+        timeout: float | None = None,
+    ) -> RunResult:
+        # Juju machines run as root; privileged flag is intentionally ignored
+        return self._juju_exec(cmd, check=check, env=env, timeout=timeout)
+
+    def put(self, local: Path, remote: str) -> None:
+        self.run(["mkdir", "-p", str(Path(remote).parent)], check=True)
+        cmd = f"juju scp {local} root@{self.name}:{remote}"
+        result = subprocess.run(shlex.split(cmd), capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise ComponentError(
+                f"Failed to push '{local}' ({local.stat().st_size} bytes) "
+                f"to '{self._name}:{remote}': {result.stderr}"
+            )
+
+    def get(self, remote: str, local: Path) -> None:
+        ensure_dir(local.parent)
+        cmd = f"juju scp root@{self._name}:{remote} {local}"
+        result = subprocess.run(shlex.split(cmd), capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise ComponentError(
+                f"Failed to pull '{self._name}:{remote}' to '{local}': {result.stderr}"
+            )
+
+
+class JujuUnitProvider(UnitProvider):
+    """Provisions and destroys Juju machines."""
+
+    @property
+    def is_ephemeral(self) -> bool:
+        return True
+
+    def _cloud_type(self) -> str:
+        cmd = ["juju", "models", "--format", "json"]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise ComponentError(f"Failed to get juju models: {result.stderr}")
+        models = json.loads(result.stdout)
+        if current_model := models.get("current-model"):
+            active = [m for m in models.get("models", []) if m.get("short-name") == current_model]
+            model_info = active[0] if active else {}
+            return str(model_info.get("type", "unknown"))
+        return "unknown"
+
+    def provision(self, role: NodeRole, index: int) -> Unit:
+        application = f"kube-galaxy-{role.value}"
+        info(f"Provisioning Juju machine '{application}' with image '{self._image}'...")
+        cloud_type = self._cloud_type()
+        if index == 0:
+            virt_type = "virt-type=virtual-machine" if cloud_type in ("lxd", "microstack") else ""
+            cmd = shlex.split(
+                f"juju deploy ch:ubuntu {application} "
+                f"--base {self._image.replace(':', '@')} "
+                f"--constraints='cores=2 mem=4G {virt_type}'"
+            )
+        else:
+            cmd = [
+                "juju",
+                "add-unit",
+                application,
+            ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise ComponentError(
+                f"Failed to launch Juju machine '{application}' {cmd=}: {result.stderr}"
+            )
+
+        return self.locate(role, index)
+
+    def locate(self, role: NodeRole, index: int) -> Unit:
+        application = f"kube-galaxy-{role.value}"
+        while not (app := _get_application_status(application)) or not app.get("units"):
+            info(f"Waiting for new juju unit '{application}' to appear...")
+            time.sleep(5)
+        # the unit with the highest index should be the one we just launched
+        unit_name = sorted(app["units"].keys())[index]
+        return JujuUnit(unit_name, role, index)
+
+    def deprovision(self, unit: Unit) -> None:
+        info(f"Deprovisioning Juju machine '{unit.name}'...")
+        if unit.index == 0:
+            cmd = ["juju", "remove-application", "--force", "--no-prompt", unit.name.split("/")[0]]
+        else:
+            cmd = ["juju", "remove-unit", "--force", "--no-prompt", unit.name]
+        subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+        )
+        self._untrack(unit)

--- a/src/kube_galaxy/pkg/units/provider.py
+++ b/src/kube_galaxy/pkg/units/provider.py
@@ -1,5 +1,6 @@
 """UnitProvider ABC and concrete implementations for machine lifecycle management."""
 
+import kube_galaxy.pkg.units.juju as juju
 import kube_galaxy.pkg.units.lxdvm as lxdvm
 import kube_galaxy.pkg.units.multipass as multipass
 import kube_galaxy.pkg.units.ssh as ssh
@@ -28,5 +29,8 @@ def provider_factory(manifest: Manifest) -> UnitProvider:
         case "ssh":
             ssh.print_dependency_status()
             return ssh.SSHUnitProvider(node_cfg, image="", hosts=cfg.hosts)
+        case "juju":
+            juju.print_dependency_status()
+            return juju.JujuUnitProvider(node_cfg, image=cfg.image)
         case _:
             raise ValueError(f"Unknown provider type: {cfg.type!r}")

--- a/src/kube_galaxy/pkg/utils/shell.py
+++ b/src/kube_galaxy/pkg/utils/shell.py
@@ -71,7 +71,7 @@ def check_version(cmd: str) -> None:
                 capture_output=True,
                 check=False,
             )
-        if cmd == "ssh":
+        elif cmd == "ssh":
             result = run(
                 [cmd, "-V"],
                 capture_output=True,

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,5 +1,6 @@
 """Unit tests for the units package: Unit ABC, LocalUnit."""
 
+import json
 import zipfile
 from pathlib import Path
 
@@ -7,10 +8,20 @@ import pytest
 
 from kube_galaxy.pkg.manifest.models import NodeRole, NodesConfig
 from kube_galaxy.pkg.units._base import RunResult, Unit
+from kube_galaxy.pkg.units.juju import (
+    JujuUnit,
+    JujuUnitProvider,
+    _get_application_status,
+    _get_state,
+    _get_unit_status,
+    _get_workload_status,
+    print_dependency_status,
+)
 from kube_galaxy.pkg.units.local import LocalUnit, LocalUnitProvider
 from kube_galaxy.pkg.units.lxdvm import LXDUnit
 from kube_galaxy.pkg.units.ssh import SSHUnit, SSHUnitProvider
 from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
+from kube_galaxy.pkg.utils.shell import ShellError
 
 # ---------------------------------------------------------------------------
 # RunResult dataclass
@@ -371,3 +382,605 @@ def test_ssh_provider_provision_all_no_extra_locate_calls():
 
     assert len(provision_calls) == 1
     assert len(locate_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# _get_state — module-level helper
+# ---------------------------------------------------------------------------
+
+_FULL_STATE = {
+    "applications": {
+        "myapp": {
+            "units": {
+                "myapp/0": {
+                    "workload-status": {"current": "active"},
+                    "juju-status": {"current": "idle"},
+                },
+            }
+        }
+    }
+}
+
+
+def _make_run_result(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return type("R", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr})()
+
+
+def test_get_state_returns_parsed_json(monkeypatch):
+    """_get_state() returns parsed dict when juju status exits 0 with valid JSON."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    result = _get_state()
+    assert result == _FULL_STATE
+
+
+def test_get_state_returns_empty_on_nonzero(monkeypatch):
+    """_get_state() returns {} when juju status exits non-zero."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(returncode=1, stdout="", stderr="error"),
+    )
+    assert _get_state() == {}
+
+
+def test_get_state_returns_empty_on_invalid_json(monkeypatch):
+    """_get_state() returns {} when output is not valid JSON."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout="not json at all"),
+    )
+    assert _get_state() == {}
+
+
+def test_get_state_returns_empty_when_json_is_not_dict(monkeypatch):
+    """_get_state() returns {} when JSON output is a list, not a dict."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout="[1, 2, 3]"),
+    )
+    assert _get_state() == {}
+
+
+# ---------------------------------------------------------------------------
+# _get_application_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_application_status_returns_app_dict(monkeypatch):
+    """`_get_application_status` extracts the application sub-dict."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    result = _get_application_status("myapp")
+    assert "units" in result
+
+
+def test_get_application_status_returns_empty_for_missing_app(monkeypatch):
+    """`_get_application_status` returns {} when app is absent from state."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    assert _get_application_status("nonexistent") == {}
+
+
+# ---------------------------------------------------------------------------
+# _get_unit_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_unit_status_returns_unit_dict(monkeypatch):
+    """`_get_unit_status` extracts the unit sub-dict."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    result = _get_unit_status("myapp/0")
+    assert "workload-status" in result
+
+
+def test_get_unit_status_returns_empty_for_missing_unit(monkeypatch):
+    """`_get_unit_status` returns {} when unit is absent."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    assert _get_unit_status("myapp/99") == {}
+
+
+# ---------------------------------------------------------------------------
+# _get_workload_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_workload_status_returns_tuple(monkeypatch):
+    """`_get_workload_status` returns (workload, juju) strings."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    result = _get_workload_status("myapp/0")
+    assert result == ("active", "idle")
+
+
+def test_get_workload_status_returns_none_for_missing_unit(monkeypatch):
+    """`_get_workload_status` returns None when unit is not found."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    assert _get_workload_status("myapp/99") is None
+
+
+# ---------------------------------------------------------------------------
+# print_dependency_status
+# ---------------------------------------------------------------------------
+
+
+def test_print_dependency_status_succeeds(monkeypatch):
+    """`print_dependency_status` completes without error when juju is available."""
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.check_version", lambda _: None)
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    print_dependency_status()  # must not raise
+
+
+def test_print_dependency_status_raises_when_juju_missing(monkeypatch):
+    """`print_dependency_status` raises ComponentError when juju is not found."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.check_version",
+        lambda _: (_ for _ in ()).throw(ShellError(["juju", "--version"], 1, "not found")),
+    )
+    with pytest.raises(ComponentError, match="'juju' not found"):
+        print_dependency_status()
+
+
+def test_print_dependency_status_raises_when_status_invalid(monkeypatch):
+    """`print_dependency_status` raises ComponentError when juju status returns no JSON."""
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.check_version", lambda _: None)
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(returncode=1),
+    )
+    with pytest.raises(ComponentError, match="did not return valid JSON"):
+        print_dependency_status()
+
+
+# ---------------------------------------------------------------------------
+# JujuUnit — basic properties
+# ---------------------------------------------------------------------------
+
+
+def test_juju_unit_name():
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    assert unit.name == "myapp/0"
+
+
+def test_juju_unit_application():
+    assert JujuUnit.application("myapp/0") == "myapp"
+    assert JujuUnit.application("other-app/3") == "other-app"
+
+
+# ---------------------------------------------------------------------------
+# JujuUnit._juju_exec
+# ---------------------------------------------------------------------------
+
+
+def test_juju_unit_exec_builds_correct_command(monkeypatch):
+    """`_juju_exec` prepends juju exec --unit <name> -- to the command."""
+    recorded: list[list[str]] = []
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit._juju_exec(["echo", "hello"])
+
+    assert recorded[0][:4] == ["juju", "exec", "--unit", "myapp/0"]
+    assert "echo" in recorded[0]
+    assert "hello" in recorded[0]
+
+
+def test_juju_unit_exec_injects_env_vars(monkeypatch):
+    """`_juju_exec` passes KEY=VALUE pairs as positional args after '--' when env is provided."""
+    recorded: list[list[str]] = []
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit._juju_exec(["env"], env={"FOO": "bar", "BAZ": "qux"})
+
+    cmd = recorded[0]
+    assert "--env" not in cmd
+    assert "FOO=bar" in cmd
+    assert "BAZ=qux" in cmd
+    # env vars must appear after '--' and before the command itself
+    sep = cmd.index("--")
+    env_section = cmd[sep + 1 :]
+    assert "FOO=bar" in env_section
+    assert "BAZ=qux" in env_section
+    assert cmd[-1] == "env"
+
+
+def test_juju_unit_exec_raises_shell_error_on_failure(monkeypatch):
+    """`_juju_exec(check=True)` raises ShellError when the command exits non-zero."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.subprocess.run",
+        lambda cmd, **kw: _make_run_result(returncode=1, stderr="boom"),
+    )
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    with pytest.raises(ShellError):
+        unit._juju_exec(["false"], check=True)
+
+
+def test_juju_unit_exec_no_raise_when_check_false(monkeypatch):
+    """`_juju_exec(check=False)` returns the result even on non-zero exit."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.subprocess.run",
+        lambda cmd, **kw: _make_run_result(returncode=1, stderr="err"),
+    )
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    result = unit._juju_exec(["false"], check=False)
+    assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# JujuUnit.run — privileged flag is silently ignored
+# ---------------------------------------------------------------------------
+
+
+def test_juju_unit_run_privileged_ignored(monkeypatch):
+    """`run(privileged=True)` behaves identically to `run(privileged=False)`."""
+    calls: list[bool] = []
+
+    def spy_exec(self, cmd, **kwargs):
+        calls.append(True)
+        return RunResult(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(JujuUnit, "_juju_exec", spy_exec)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit.run(["hostname"], privileged=True)
+    unit.run(["hostname"], privileged=False)
+
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# JujuUnit.put
+# ---------------------------------------------------------------------------
+
+
+def test_juju_unit_put_builds_correct_command(monkeypatch, tmp_path):
+    """`put()` pre-creates the remote directory then calls juju scp with name:remote format."""
+    src = tmp_path / "file.txt"
+    src.write_bytes(b"data")
+
+    recorded: list[list[str]] = []
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit.put(src, "/remote/path/file.txt")
+
+    # First call: juju exec mkdir -p
+    assert "mkdir" in recorded[0]
+    # Second call: juju scp
+    scp_cmd = recorded[1]
+    assert "juju" in scp_cmd
+    assert "scp" in scp_cmd
+    assert str(src) in scp_cmd
+    assert "root@myapp/0:/remote/path/file.txt" in scp_cmd
+
+
+def test_juju_unit_put_raises_component_error_on_failure(monkeypatch, tmp_path):
+    """`put()` raises ComponentError when juju scp fails (mkdir succeeds)."""
+    src = tmp_path / "file.txt"
+    src.write_bytes(b"data")
+
+    call_count = {"n": 0}
+
+    def fake_subproc(cmd, **kw):
+        call_count["n"] += 1
+        # First call is juju exec mkdir — let it succeed
+        if call_count["n"] == 1:
+            return _make_run_result()
+        # Second call is juju scp — make it fail
+        return _make_run_result(returncode=1, stderr="connection refused")
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    with pytest.raises(ComponentError, match="Failed to push"):
+        unit.put(src, "/remote/path/file.txt")
+
+
+# ---------------------------------------------------------------------------
+# JujuUnit.get
+# ---------------------------------------------------------------------------
+
+
+def test_juju_unit_get_builds_correct_command(monkeypatch, tmp_path):
+    """`get()` calls juju scp with correct source and destination."""
+    dest = tmp_path / "out" / "file.txt"
+    recorded: list[list[str]] = []
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit.get("/remote/file.txt", dest)
+
+    assert "juju" in recorded[0]
+    assert "scp" in recorded[0]
+    assert "root@myapp/0:/remote/file.txt" in recorded[0]
+    assert str(dest) in recorded[0]
+
+
+def test_juju_unit_get_raises_component_error_on_failure(monkeypatch, tmp_path):
+    """`get()` raises ComponentError when juju scp fails."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.subprocess.run",
+        lambda cmd, **kw: _make_run_result(returncode=1, stderr="no such file"),
+    )
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    with pytest.raises(ComponentError, match="Failed to pull"):
+        unit.get("/remote/missing.txt", tmp_path / "out.txt")
+
+
+# ---------------------------------------------------------------------------
+# JujuUnit.enlist
+# ---------------------------------------------------------------------------
+
+
+def test_juju_unit_enlist_returns_immediately_when_active_idle(monkeypatch):
+    """`enlist()` returns immediately when unit is already active/idle."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(stdout=json.dumps(_FULL_STATE)),
+    )
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.subprocess.run",
+        lambda cmd, **kw: _make_run_result(),
+    )
+    monkeypatch.setattr("kube_galaxy.pkg.units._base.Unit.update_etc_hosts", lambda self: None)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit.enlist(timeout=30)  # must not raise
+
+
+def test_juju_unit_enlist_retries_until_active_idle(monkeypatch):
+    """`enlist()` retries until the unit reports active/idle."""
+    state_with_maintenance = {
+        "applications": {
+            "myapp": {
+                "units": {
+                    "myapp/0": {
+                        "workload-status": {"current": "maintenance"},
+                        "juju-status": {"current": "executing"},
+                    }
+                }
+            }
+        }
+    }
+    attempt = {"count": 0}
+
+    def fake_run(cmd, **kw):
+        attempt["count"] += 1
+        if attempt["count"] >= 3:
+            return _make_run_result(stdout=json.dumps(_FULL_STATE))
+        return _make_run_result(stdout=json.dumps(state_with_maintenance))
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.run", fake_run)
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.subprocess.run",
+        lambda cmd, **kw: _make_run_result(),
+    )
+    monkeypatch.setattr("kube_galaxy.pkg.units._base.Unit.update_etc_hosts", lambda self: None)
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.time.sleep", lambda _: None)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    unit.enlist(timeout=60)
+
+    assert attempt["count"] >= 3
+
+
+def test_juju_unit_enlist_raises_on_timeout(monkeypatch):
+    """`enlist()` raises ClusterError when timeout elapses without becoming active/idle."""
+    times = iter([0.0, 0.0, 9999.0])
+
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.run",
+        lambda cmd, **kw: _make_run_result(returncode=1),
+    )
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.time.sleep", lambda _: None)
+
+    unit = JujuUnit("myapp/0", NodeRole.CONTROL_PLANE, 0)
+    with pytest.raises(ClusterError, match="Timed out waiting for unit 'myapp/0'"):
+        unit.enlist(timeout=120)
+
+
+# ---------------------------------------------------------------------------
+# JujuUnitProvider
+# ---------------------------------------------------------------------------
+
+
+def test_juju_provider_is_ephemeral():
+    """`JujuUnitProvider.is_ephemeral` must be True."""
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=0), image="ubuntu:22.04")
+    assert p.is_ephemeral is True
+
+
+def test_juju_provider_provision_index0_deploys(monkeypatch):
+    """`provision(index=0)` runs `juju deploy`."""
+    recorded: list[list[str]] = []
+
+    _models_response = json.dumps(
+        {"current-model": "default", "models": [{"short-name": "default", "type": "lxd"}]}
+    )
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        # Return model JSON for the _cloud_type() call, success for everything else
+        if "models" in cmd:
+            return _make_run_result(stdout=_models_response)
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju._get_application_status",
+        lambda app, **kw: {
+            "units": {"kube-galaxy-control-plane/0": {"workload-status": {"current": "active"}}}
+        },
+    )
+
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=0), image="ubuntu:22.04")
+    unit = p.provision(NodeRole.CONTROL_PLANE, 0)
+
+    assert any("deploy" in cmd for cmd in recorded)
+    assert isinstance(unit, JujuUnit)
+
+
+def test_juju_provider_provision_index1_adds_unit(monkeypatch):
+    """`provision(index>0)` runs `juju add-unit` instead of deploy."""
+    recorded: list[list[str]] = []
+
+    _models_response = json.dumps(
+        {"current-model": "default", "models": [{"short-name": "default", "type": "lxd"}]}
+    )
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        if "models" in cmd:
+            return _make_run_result(stdout=_models_response)
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju._get_application_status",
+        lambda app, **kw: {
+            "units": {
+                "kube-galaxy-worker/0": {"workload-status": {"current": "active"}},
+                "kube-galaxy-worker/1": {"workload-status": {"current": "active"}},
+            }
+        },
+    )
+
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=2), image="ubuntu:22.04")
+    unit = p.provision(NodeRole.WORKER, 1)
+
+    assert any("add-unit" in cmd for cmd in recorded)
+    assert isinstance(unit, JujuUnit)
+
+
+def test_juju_provider_provision_raises_on_failure(monkeypatch):
+    """`provision()` raises ComponentError when juju deploy/add-unit fails."""
+    _models_response = json.dumps(
+        {"current-model": "default", "models": [{"short-name": "default", "type": "lxd"}]}
+    )
+
+    def fake_subproc(cmd, **kw):
+        if "models" in cmd:
+            return _make_run_result(stdout=_models_response)
+        return _make_run_result(returncode=1, stderr="deploy failed")
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=0), image="ubuntu:22.04")
+    with pytest.raises(ComponentError, match="Failed to launch Juju machine"):
+        p.provision(NodeRole.CONTROL_PLANE, 0)
+
+
+def test_juju_provider_locate_returns_unit_by_sorted_index(monkeypatch):
+    """`locate()` returns the JujuUnit at the sorted position matching `index`."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju._get_application_status",
+        lambda app, **kw: {
+            "units": {
+                "kube-galaxy-worker/2": {},
+                "kube-galaxy-worker/0": {},
+                "kube-galaxy-worker/1": {},
+            }
+        },
+    )
+
+    p = JujuUnitProvider(NodesConfig(control_plane=0, worker=3), image="ubuntu:22.04")
+    unit = p.locate(NodeRole.WORKER, 1)
+
+    assert isinstance(unit, JujuUnit)
+    assert unit.name == "kube-galaxy-worker/1"
+
+
+def test_juju_provider_deprovision_index0_removes_application(monkeypatch):
+    """`deprovision(unit)` for index 0 runs `juju remove-application`."""
+    recorded: list[list[str]] = []
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=0), image="ubuntu:22.04")
+    unit = JujuUnit("kube-galaxy-control-plane/0", NodeRole.CONTROL_PLANE, 0)
+    p._track(unit)
+    p.deprovision(unit)
+
+    assert any("remove-application" in cmd for cmd in recorded)
+
+
+def test_juju_provider_deprovision_index1_removes_unit(monkeypatch):
+    """`deprovision(unit)` for index > 0 runs `juju remove-unit`."""
+    recorded: list[list[str]] = []
+
+    def fake_subproc(cmd, **kwargs):
+        recorded.append(list(cmd))
+        return _make_run_result()
+
+    monkeypatch.setattr("kube_galaxy.pkg.units.juju.subprocess.run", fake_subproc)
+
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=2), image="ubuntu:22.04")
+    unit = JujuUnit("kube-galaxy-worker/1", NodeRole.WORKER, 1)
+    p._track(unit)
+    p.deprovision(unit)
+
+    assert any("remove-unit" in cmd for cmd in recorded)
+
+
+def test_juju_provider_deprovision_untracks_unit(monkeypatch):
+    """`deprovision()` removes the unit from the tracked set."""
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.units.juju.subprocess.run",
+        lambda cmd, **kw: _make_run_result(),
+    )
+
+    p = JujuUnitProvider(NodesConfig(control_plane=1, worker=0), image="ubuntu:22.04")
+    unit = JujuUnit("kube-galaxy-control-plane/0", NodeRole.CONTROL_PLANE, 0)
+    p._track(unit)
+    assert len(p._units) == 1
+
+    p.deprovision(unit)
+    assert len(p._units) == 0


### PR DESCRIPTION
This pull request adds support for Juju as a unit provider in the `kube_galaxy` project, enabling provisioning and management of cluster nodes using Juju machines. It introduces new abstractions for Juju-based units, integrates Juju into the provider factory, and makes several related refactors and bugfixes to support this addition. The changes also unify and clarify removal logic for components, and fix how hostnames are accessed throughout the codebase.

**Juju provider integration:**

* Added new `JujuUnit` and `JujuUnitProvider` classes in `src/kube_galaxy/pkg/units/juju.py` to support provisioning, executing commands, and file transfer on Juju machines. Includes dependency checks, workload status polling, and lifecycle management.
* Registered the Juju provider in the provider factory (`src/kube_galaxy/pkg/units/provider.py`), allowing manifests to specify `juju` as a provider type. [[1]](diffhunk://#diff-5c25d6a09252028ec9863a6eb3dd1a8b00fe931a65f42110947b07feaf342085R3) [[2]](diffhunk://#diff-5c25d6a09252028ec9863a6eb3dd1a8b00fe931a65f42110947b07feaf342085R32-R34)
* Allowed `juju` as a valid provider type in manifest validation (`src/kube_galaxy/pkg/manifest/validator.py`).

**Component removal and lifecycle refactor:**

* Unified removal logic by replacing the `remove` hook/strategy with `delete`, updating the base strategy classes (`src/kube_galaxy/pkg/components/strategies/_base.py`) and refactoring component hooks to use `delete` for teardown. [[1]](diffhunk://#diff-1d5ef57be5ff1f321813b3c8405015ace15c248b8c98cd8143126fe982b4552dL48-R48) [[2]](diffhunk://#diff-1d5ef57be5ff1f321813b3c8405015ace15c248b8c98cd8143126fe982b4552dL59-R59) [[3]](diffhunk://#diff-9284e1434d18989a884f9426dcc87d55b14738c34b8687d5dc275603915530e7L238-L247) [[4]](diffhunk://#diff-9284e1434d18989a884f9426dcc87d55b14738c34b8687d5dc275603915530e7L315-R310)
* Implemented `delete` methods for binary and archive install strategies to properly clean up component directories and alternatives (`src/kube_galaxy/pkg/components/strategies/binary.py`, `src/kube_galaxy/pkg/components/strategies/binary_archive.py`). [[1]](diffhunk://#diff-0f55ba1d5b7a9484d6393ef28482b9700bf48d07278015406d676ac37e0f8972L25-R33) [[2]](diffhunk://#diff-c57f4fa0a9e54704cf8bb3528be5cda4ae2044f6d78d9ab0384ff9f59a458769L50-R60)

**Bugfixes and code consistency:**

* Changed all calls to retrieve a unit's hostname from `self.unit.hostname()` to the property `self.unit.hostname` for consistency and to match the new `@cached_property` usage. [[1]](diffhunk://#diff-9284e1434d18989a884f9426dcc87d55b14738c34b8687d5dc275603915530e7L170-R169) [[2]](diffhunk://#diff-7ba701716aa2bd4629dd7ccebe02c04ae5ec63da22cfb6fc2d36d40a01d84185L92-R92) [[3]](diffhunk://#diff-7ba701716aa2bd4629dd7ccebe02c04ae5ec63da22cfb6fc2d36d40a01d84185L190-R190) [[4]](diffhunk://#diff-2ac3fe22bed5e21aa0eff59eaca66c61dd4673866cfe0e297d0f7fe17508a768R164)
* Made `hostname` a cached property in the `Unit` base class for efficiency and clarity (`src/kube_galaxy/pkg/units/_base.py`).
* Added `ENLIST_TIMEOUT` constant to `Unit` base class for standardized timeouts.
* Minor fix to version checking logic for `ssh` in `check_version` utility (`src/kube_galaxy/pkg/utils/shell.py`).