### PR TITLE
Simplify the reusable-workflow to install kgt from a ref

### DIFF
--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -116,7 +116,7 @@ jobs:
         shell: bash
         run: |
           echo "## Test Configuration"
-          echo "- **Manifest**: ${{ steps.manifest.outputs.path }}"
+          echo "- **Manifest**: ${{ matrix.manifest-file }}"
           echo "- **Runner**: ubuntu-latest"
           echo "- **Timeout**: ${{ inputs.timeout-minutes }} minutes"
 
@@ -131,7 +131,7 @@ jobs:
           ARTIFACT_NAME=$(echo "${{ matrix.manifest-file }}" | sed 's/\//-/g')
           echo "artifact-name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
-          kube-galaxy setup ${{ steps.manifest.outputs.path }}
+          kube-galaxy setup ${{ matrix.manifest-file }}
 
       - name: Verify Cluster Health
         shell: bash
@@ -142,7 +142,7 @@ jobs:
         id: run-tests
         shell: bash
         run: |
-          kube-galaxy test ${{ steps.manifest.outputs.path }}
+          kube-galaxy test ${{ matrix.manifest-file }}
 
       - name: Collect Logs
         if: always()

--- a/.github/workflows/test-baseline-clusters.yml
+++ b/.github/workflows/test-baseline-clusters.yml
@@ -106,6 +106,8 @@ jobs:
     if: needs.discover-manifests.outputs.manifests != '[]'
     uses: ./.github/workflows/reusable-cluster-test.yml
     with:
+      manifests-repo: ${{ github.repository }}
+      manifests-ref: ${{ github.head_ref || github.ref_name }}
       kube-galaxy-ref: ${{ github.head_ref || github.ref_name }}
       manifests-json: ${{ needs.discover-manifests.outputs.manifests }}
       create-issues-on-failure: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Rather than the callable directory expect kgt to work from its checked out space, just install kgt and use whatever manifests are local from the calling repo.