### PR TITLE
Include docker.io credentials if available for containerd

### DIFF
--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -126,6 +126,8 @@ jobs:
         env:
           GITHUB_ACTOR: cdkbot
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           # Sanitized name for artifact uploads
           ARTIFACT_NAME=$(echo "${{ matrix.manifest-file }}" | sed 's/\//-/g')

--- a/src/kube_galaxy/pkg/components/containerd.py
+++ b/src/kube_galaxy/pkg/components/containerd.py
@@ -7,6 +7,7 @@ Containerd is the container runtime used by Kubernetes clusters.
 import time
 from pathlib import Path
 
+import kube_galaxy.pkg.utils.dockerio  # noqa: F401  # register dockerhub auth provider
 from kube_galaxy.pkg.components import ComponentBase, register_component
 from kube_galaxy.pkg.literals import Permissions, URLs
 from kube_galaxy.pkg.manifest.models import InstallMethod
@@ -31,7 +32,14 @@ def _registry_auth(component: "ComponentBase", host: str, auth: str) -> None:
         auth: Authentication string (e.g., "Basic <base64-encoded-credentials>")
     """
     hosts_tmpl = Path(__file__).parent / "templates/containerd/auth-hosts.toml"
-    content = hosts_tmpl.read_text().format(host=host, authorization=auth)
+    if host == "docker.io":
+        # Dockerhub uses registry-1.docker.io as the registry host
+        registry_host = "registry-1.docker.io"
+    else:
+        registry_host = host
+    content = hosts_tmpl.read_text().format(
+        host=host, registry_host=registry_host, authorization=auth
+    )
 
     hosts_toml = HOSTS_D / host / "hosts.toml"
     component.write_config_file(content, hosts_toml, mode=Permissions.PRIVATE)

--- a/src/kube_galaxy/pkg/components/templates/containerd/auth-hosts.toml
+++ b/src/kube_galaxy/pkg/components/templates/containerd/auth-hosts.toml
@@ -1,7 +1,7 @@
 server = "https://{host}"
 
-[host."https://{host}"]
+[host."https://{registry_host}"]
   capabilities = ["pull", "resolve"]
 
-  [host."https://{host}".header]
+  [host."https://{registry_host}".header]
     Authorization = "{authorization}"

--- a/src/kube_galaxy/pkg/utils/dockerio.py
+++ b/src/kube_galaxy/pkg/utils/dockerio.py
@@ -1,0 +1,44 @@
+"""Dockerhub integration utilities.
+
+Provides helper functions for constructing authentication headers for Docker
+registries based on environment variables and Docker config files.
+"""
+
+import base64
+import os
+
+from kube_galaxy.pkg.utils.logging import info
+from kube_galaxy.pkg.utils.url import register_headers_provider
+
+DOCKERHUB_USERNAME = os.getenv("DOCKERHUB_USERNAME")
+DOCKERHUB_TOKEN = os.getenv("DOCKERHUB_TOKEN")
+
+
+def dh_auth_basic() -> str:
+    """Construct a Basic auth header for Dockerhub authentication from
+    * DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
+
+    Returns:
+        A string in the format Basic <base64-encoded credentials> otherwise an empty string.
+    """
+    username, password = None, None
+    if DOCKERHUB_USERNAME and DOCKERHUB_TOKEN:
+        info("    Using DOCKERHUB_USERNAME and DOCKERHUB_TOKEN for docker.io authentication")
+        username, password = DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+    if username and password:
+        credentials = f"{username}:{password}"
+        encoded_credentials = base64.b64encode(credentials.encode()).decode()
+        return f"Basic {encoded_credentials}"
+    return ""
+
+
+@register_headers_provider("docker.io")
+def dh_http_headers(**kwargs: bool | str) -> dict[str, str]:
+    """Construct standard headers for docker.io requests, including authentication if available."""
+    headers = {}
+    if kwargs.get("raw"):
+        headers["Accept"] = "application/vnd.docker.raw+json"
+    if kwargs.get("basic_auth") and (gh_auth := dh_auth_basic()):
+        headers["Authorization"] = gh_auth
+
+    return headers

--- a/src/kube_galaxy/pkg/utils/gh.py
+++ b/src/kube_galaxy/pkg/utils/gh.py
@@ -85,7 +85,7 @@ def gh_http_headers(**kwargs: bool | str) -> dict[str, str]:
         headers["Accept"] = "application/vnd.github.raw+json"
     if bearer := gh_auth_bearer():
         headers["Authorization"] = bearer
-    if kwargs.get("basic-auth") and (gh_auth := gh_auth_basic()):
+    if kwargs.get("basic_auth") and (gh_auth := gh_auth_basic()):
         headers["Authorization"] = gh_auth
 
     return headers

--- a/tests/unit/test_dockerio.py
+++ b/tests/unit/test_dockerio.py
@@ -1,0 +1,118 @@
+"""Unit tests for kube_galaxy.pkg.utils.dockerio."""
+
+import base64
+from unittest.mock import patch
+
+from kube_galaxy.pkg.utils.dockerio import dh_auth_basic, dh_http_headers
+
+
+def _basic(username: str, token: str) -> str:
+    """Return the expected Basic auth header value for given credentials."""
+    return "Basic " + base64.b64encode(f"{username}:{token}".encode()).decode()
+
+
+# ---------------------------------------------------------------------------
+# dh_auth_basic
+# ---------------------------------------------------------------------------
+
+
+class TestDhAuthBasic:
+    def test_returns_empty_when_no_env_vars(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", None),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", None),
+        ):
+            assert dh_auth_basic() == ""
+
+    def test_returns_empty_when_only_username_set(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", "user"),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", None),
+        ):
+            assert dh_auth_basic() == ""
+
+    def test_returns_empty_when_only_token_set(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", None),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", "tok"),
+        ):
+            assert dh_auth_basic() == ""
+
+    def test_returns_basic_auth_when_both_set(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", "user"),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", "tok"),
+        ):
+            assert dh_auth_basic() == _basic("user", "tok")
+
+    def test_credentials_are_base64_encoded(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", "alice"),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", "s3cr3t"),
+        ):
+            result = dh_auth_basic()
+        assert result.startswith("Basic ")
+        decoded = base64.b64decode(result[len("Basic ") :]).decode()
+        assert decoded == "alice:s3cr3t"
+
+
+# ---------------------------------------------------------------------------
+# dh_http_headers
+# ---------------------------------------------------------------------------
+
+
+class TestDhHttpHeaders:
+    def test_returns_default_headers_without_credentials(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", None),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", None),
+        ):
+            headers = dh_http_headers()
+
+        assert "Authorization" not in headers
+
+    def test_no_auth_header_without_basic_auth_kwarg(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", "user"),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", "tok"),
+        ):
+            headers = dh_http_headers()
+
+        assert "Authorization" not in headers
+
+    def test_basic_auth_kwarg_adds_authorization_header(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", "user"),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", "tok"),
+        ):
+            headers = dh_http_headers(basic_auth=True)
+
+        assert headers["Authorization"] == _basic("user", "tok")
+
+    def test_basic_auth_kwarg_without_credentials_omits_authorization(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", None),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", None),
+        ):
+            headers = dh_http_headers(basic_auth=True)
+
+        assert "Authorization" not in headers
+
+    def test_raw_kwarg_changes_accept_header(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", None),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", None),
+        ):
+            headers = dh_http_headers(raw=True)
+
+        assert headers["Accept"] == "application/vnd.docker.raw+json"
+
+    def test_raw_and_basic_auth_combined(self) -> None:
+        with (
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_USERNAME", "user"),
+            patch("kube_galaxy.pkg.utils.dockerio.DOCKERHUB_TOKEN", "tok"),
+        ):
+            headers = dh_http_headers(raw=True, basic_auth=True)
+
+        assert headers["Accept"] == "application/vnd.docker.raw+json"
+        assert headers["Authorization"] == _basic("user", "tok")


### PR DESCRIPTION
This pull request introduces Docker Hub authentication support for the `kube_galaxy` project, enabling components to authenticate with Docker Hub using credentials provided via environment variables. The changes include a new utility for handling Docker Hub authentication, updates to the containerd configuration logic, and comprehensive unit tests.

**Docker Hub authentication integration:**

* Added a new utility module `kube_galaxy.pkg.utils.dockerio` that provides functions to construct Docker Hub Basic authentication headers from the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` environment variables, and registers a headers provider for Docker Hub requests.
* Updated the GitHub Actions workflow (`.github/workflows/reusable-cluster-test.yml`) to pass Docker Hub credentials as environment variables to jobs.

**Containerd registry authentication improvements:**

* Modified the containerd component to use the new Docker Hub authentication utility and ensure the correct registry host (`registry-1.docker.io`) is used for Docker Hub in the generated `hosts.toml` config. [[1]](diffhunk://#diff-719aa6d1e905ec424404e25d42b9b3ccc181fe407009b1267e99d58b03b1cc91R10) [[2]](diffhunk://#diff-719aa6d1e905ec424404e25d42b9b3ccc181fe407009b1267e99d58b03b1cc91L34-R42) [[3]](diffhunk://#diff-5ad3265346d3c78d97e26b802123582bb911897c7867b34bb1e9e8cf485da795L3-R6)

**Testing and code quality:**

* Added comprehensive unit tests in `tests/unit/test_dockerio.py` to verify Docker Hub authentication header generation and HTTP header construction under various scenarios.
* Fixed a minor bug in the GitHub headers utility to use the correct keyword argument (`basic_auth`) for consistency.