### PR TITLE
Support pulling releases from internal repos

### DIFF
--- a/src/kube_galaxy/pkg/utils/components.py
+++ b/src/kube_galaxy/pkg/utils/components.py
@@ -14,7 +14,11 @@ from kube_galaxy.pkg.literals import Permissions, SystemPaths, URLs
 from kube_galaxy.pkg.manifest.models import ComponentConfig, RepoInfo
 from kube_galaxy.pkg.utils.detector import ArchInfo
 from kube_galaxy.pkg.utils.errors import ComponentError
-from kube_galaxy.pkg.utils.gh import gh_extract_artifact_file
+from kube_galaxy.pkg.utils.gh import (
+    gh_download_release_asset,
+    gh_extract_artifact_file,
+    gh_match_release_asset,
+)
 from kube_galaxy.pkg.utils.paths import ensure_dir
 from kube_galaxy.pkg.utils.url import http_headers
 
@@ -47,6 +51,10 @@ def download_file(url: str, dest: Path, verify_sha256: str | None = None) -> Non
     ensure_dir(dest.parent)
     if url.startswith("gh-artifact://"):
         gh_extract_artifact_file(url, dest)
+        return
+
+    if src := gh_match_release_asset(url):
+        gh_download_release_asset(src, dest)
         return
 
     if url.startswith("local://"):

--- a/src/kube_galaxy/pkg/utils/gh.py
+++ b/src/kube_galaxy/pkg/utils/gh.py
@@ -7,9 +7,11 @@ environments using the GITHUB_OUTPUT mechanism for inter-step communication.
 import base64
 import io
 import os
+import re
 import typing
 import uuid
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 
 import requests
@@ -17,16 +19,31 @@ from github import Auth, Github, GithubException
 from github.Artifact import Artifact
 
 from kube_galaxy.pkg.utils.errors import ComponentError
-from kube_galaxy.pkg.utils.logging import info
+from kube_galaxy.pkg.utils.logging import info, warning
 from kube_galaxy.pkg.utils.url import http_headers, register_headers_provider
 
 # GitHub Actions sets this environment variable pointing to the output file
+GITHUB_API = "https://api.github.com"
 GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS")
 GITHUB_OUTPUT = os.getenv("GITHUB_OUTPUT")
 GITHUB_REPOSITORY = os.getenv("GITHUB_REPOSITORY")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 GITHUB_ACTOR = os.getenv("GITHUB_ACTOR")
 GITHUB_USERNAME = os.getenv("GITHUB_USERNAME")
+GITHUB_RELEASE_ASSET = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(.+)$"
+)
+
+
+@dataclass
+class GHReleaseAssetInfo:
+    """Structured information parsed from a GitHub release asset URL."""
+
+    owner: str  # "owner"
+    repo: str  # "repo"
+    tag: str  # Release tag (e.g., "v1.2.3")
+    filename: str  # Asset filename (e.g., "my-binary-linux-amd64.tar.gz")
+
 
 if typing.TYPE_CHECKING:
     # Define a Reader protocol for type hinting (io.Reader is not yet in mypy stubs)
@@ -40,6 +57,25 @@ def _write_chunked(infile: "Reader", outfile: io.BufferedWriter) -> None:
     """Write data to a file in chunks to handle large content without loading it all into memory."""
     while chunk := infile.read(8192):
         outfile.write(chunk)
+
+
+def gh_match_release_asset(url: str) -> GHReleaseAssetInfo | None:
+    """Check if a URL matches the pattern of a GitHub release asset."""
+
+    # https://github.com/{owner}/{repo}/releases/download/{tag}/{filename}
+    match = GITHUB_RELEASE_ASSET.match(url)
+    if not match:
+        return None
+
+    if not GITHUB_TOKEN:
+        warning(
+            f"{url} is a GitHub release asset but GITHUB_TOKEN "
+            "is unset; cannot download private assets."
+        )
+        return None
+
+    owner, repo, tag, filename = match.groups()
+    return GHReleaseAssetInfo(owner=owner, repo=repo, tag=tag, filename=filename)
 
 
 def gh_auth_bearer() -> str:
@@ -80,9 +116,14 @@ def gh_http_headers(**kwargs: bool | str) -> dict[str, str]:
 
     For GitHub API requests, include the API version and authentication token if available.
     """
-    headers = {"X-GitHub-Api-Version": "2022-11-28", "Accept": "application/vnd.github+json"}
+    headers = {"X-GitHub-Api-Version": "2022-11-28"}
     if kwargs.get("raw"):
         headers["Accept"] = "application/vnd.github.raw+json"
+    elif accept := kwargs.get("accept"):
+        headers["Accept"] = str(accept)
+    else:
+        headers["Accept"] = "application/vnd.github+json"
+
     if bearer := gh_auth_bearer():
         headers["Authorization"] = bearer
     if kwargs.get("basic_auth") and (gh_auth := gh_auth_basic()):
@@ -151,6 +192,68 @@ def gh_list_artifacts_by_name(artifact_name: str) -> list[Artifact]:
     if not matching_artifacts:
         raise ComponentError(f"No artifact named '{artifact_name}' found in {GITHUB_REPOSITORY}")
     return matching_artifacts
+
+
+def gh_download_release_asset(src: GHReleaseAssetInfo, dest: Path) -> None:
+    """Download a GitHub release asset (works for private repos via token)."""
+    repo_full = f"{src.owner}/{src.repo}"
+    # ------------------------------------------------------------
+    # 1. Resolve release by tag (REST API, no PyGithub)
+    # ------------------------------------------------------------
+    try:
+        release_resp = requests.get(
+            f"{GITHUB_API}/repos/{repo_full}/releases/tags/{src.tag}",
+            headers=gh_http_headers(),
+            timeout=30,
+        )
+        release_resp.raise_for_status()
+        release = release_resp.json()
+    except requests.RequestException as exc:
+        raise ComponentError(
+            f"Failed to fetch release '{src.tag}' for '{repo_full}': {exc}"
+        ) from exc
+
+    # ------------------------------------------------------------
+    # 2. Find asset by name
+    # ------------------------------------------------------------
+    asset = next(
+        (a for a in release.get("assets", []) if a.get("name") == src.filename),
+        None,
+    )
+
+    if not asset:
+        available = ", ".join(a["name"] for a in release.get("assets", []))
+        raise ComponentError(
+            f"Asset '{src.filename}' not found in release '{src.tag}' of '{repo_full}'.\n"
+            f"Available: {available}"
+        )
+
+    asset_id = asset["id"]
+
+    # ------------------------------------------------------------
+    # 3. Download via asset API endpoint (DO NOT manually handle redirects)
+    # ------------------------------------------------------------
+    download_url = f"{GITHUB_API}/repos/{repo_full}/releases/assets/{asset_id}"
+
+    try:
+        with requests.get(
+            download_url,
+            headers=gh_http_headers(accept="application/octet-stream"),
+            stream=True,
+            timeout=300,
+            allow_redirects=True,
+        ) as resp:
+            resp.raise_for_status()
+
+            with open(dest, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        f.write(chunk)
+
+    except requests.RequestException as exc:
+        raise ComponentError(
+            f"Failed to download asset '{src.filename}' from '{repo_full}': {exc}"
+        ) from exc
 
 
 def gh_download_artifact(artifact: Artifact, dest: Path) -> Path:

--- a/tests/unit/components/test_base_utils.py
+++ b/tests/unit/components/test_base_utils.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 from kube_galaxy.pkg.cluster_context import ClusterContext
 from kube_galaxy.pkg.components._base import ComponentBase
 from kube_galaxy.pkg.literals import SystemPaths
@@ -15,7 +18,12 @@ from kube_galaxy.pkg.manifest.models import (
     TestMethod as ComponentTestMethod,
 )
 from kube_galaxy.pkg.units._base import RunResult
-from kube_galaxy.pkg.utils.components import format_component_pattern, install_from_archive
+from kube_galaxy.pkg.utils.components import (
+    download_file,
+    format_component_pattern,
+    install_from_archive,
+)
+from kube_galaxy.pkg.utils.gh import GHReleaseAssetInfo
 from tests.unit.components.conftest import MockUnit
 
 
@@ -434,3 +442,48 @@ def test_install_from_archive_no_match_returns_empty(tmp_path):
     result = install_from_archive(archive, "nonexistent-*", "mytool", mock_unit)
 
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# download_file — GitHub release asset routing
+# ---------------------------------------------------------------------------
+
+
+def test_download_file_routes_gh_release_asset_url(tmp_path: Path) -> None:
+    """download_file calls gh_download_release_asset when URL matches GH release pattern."""
+    dest = tmp_path / "binary"
+    asset_info = GHReleaseAssetInfo(owner="org", repo="repo", tag="v1.0", filename="binary")
+    url = "https://github.com/org/repo/releases/download/v1.0/binary"
+
+    with (
+        patch(
+            "kube_galaxy.pkg.utils.components.gh_match_release_asset",
+            return_value=asset_info,
+        ) as mock_match,
+        patch("kube_galaxy.pkg.utils.components.gh_download_release_asset") as mock_dl,
+    ):
+        download_file(url, dest)
+
+    mock_match.assert_called_once_with(url)
+    mock_dl.assert_called_once_with(asset_info, dest)
+
+
+def test_download_file_falls_through_when_gh_release_asset_no_match(tmp_path: Path) -> None:
+    """download_file skips gh_download_release_asset when gh_match_release_asset returns None."""
+    dest = tmp_path / "output"
+    content = b"file content"
+    url = "https://github.com/org/repo/releases/download/v1.0/binary"
+
+    mock_resp = MagicMock()
+    mock_resp.read.side_effect = [content, b""]
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("kube_galaxy.pkg.utils.components.gh_match_release_asset", return_value=None),
+        patch("kube_galaxy.pkg.utils.components.gh_download_release_asset") as mock_dl,
+        patch("kube_galaxy.pkg.utils.components.urllib.request.urlopen", return_value=mock_resp),
+    ):
+        download_file(url, dest)
+
+    mock_dl.assert_not_called()

--- a/tests/unit/test_gh.py
+++ b/tests/unit/test_gh.py
@@ -13,9 +13,13 @@ from github import GithubException
 
 from kube_galaxy.pkg.utils.errors import ComponentError
 from kube_galaxy.pkg.utils.gh import (
+    GHReleaseAssetInfo,
     gh_download_artifact,
+    gh_download_release_asset,
     gh_extract_artifact_file,
+    gh_http_headers,
     gh_list_artifacts_by_name,
+    gh_match_release_asset,
     gh_output,
 )
 
@@ -352,3 +356,187 @@ class TestGhExtractArtifactFile:
             gh_extract_artifact_file("gh-artifact://art/f.txt", dest)
 
         assert captured[0].id == 2  # newer artifact selected
+
+
+# ---------------------------------------------------------------------------
+# gh_http_headers
+# ---------------------------------------------------------------------------
+
+
+class TestGhHttpHeaders:
+    def test_default_accept_is_vnd_github_json(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", None):
+            headers = gh_http_headers()
+        assert headers["Accept"] == "application/vnd.github+json"
+
+    def test_raw_flag_sets_raw_accept(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", None):
+            headers = gh_http_headers(raw=True)
+        assert headers["Accept"] == "application/vnd.github.raw+json"
+
+    def test_custom_accept_kwarg(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", None):
+            headers = gh_http_headers(accept="application/octet-stream")
+        assert headers["Accept"] == "application/octet-stream"
+
+    def test_raw_takes_precedence_over_accept_kwarg(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", None):
+            headers = gh_http_headers(raw=True, accept="application/octet-stream")
+        assert headers["Accept"] == "application/vnd.github.raw+json"
+
+    def test_api_version_always_present(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", None):
+            headers = gh_http_headers()
+        assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+# ---------------------------------------------------------------------------
+# gh_match_release_asset
+# ---------------------------------------------------------------------------
+
+
+class TestGhMatchReleaseAsset:
+    _VALID_URL = "https://github.com/owner/repo/releases/download/v1.2.3/binary-linux-amd64"
+
+    def test_returns_info_for_valid_url_with_token(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", "tok"):
+            result = gh_match_release_asset(self._VALID_URL)
+        assert result is not None
+        assert result.owner == "owner"
+        assert result.repo == "repo"
+        assert result.tag == "v1.2.3"
+        assert result.filename == "binary-linux-amd64"
+
+    def test_returns_none_for_non_github_url(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", "tok"):
+            result = gh_match_release_asset("https://example.com/file.tar.gz")
+        assert result is None
+
+    def test_returns_none_for_github_url_without_release_path(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", "tok"):
+            result = gh_match_release_asset("https://github.com/owner/repo/tags")
+        assert result is None
+
+    def test_returns_none_when_token_not_set(self) -> None:
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", None):
+            result = gh_match_release_asset(self._VALID_URL)
+        assert result is None
+
+    def test_parses_complex_filename_with_dots_and_dashes(self) -> None:
+        url = "https://github.com/org/project/releases/download/2.0.1/project-2.0.1-linux-arm64.tar.gz"
+        with patch("kube_galaxy.pkg.utils.gh.GITHUB_TOKEN", "tok"):
+            result = gh_match_release_asset(url)
+        assert result is not None
+        assert result.tag == "2.0.1"
+        assert result.filename == "project-2.0.1-linux-arm64.tar.gz"
+
+
+# ---------------------------------------------------------------------------
+# gh_download_release_asset
+# ---------------------------------------------------------------------------
+
+
+class TestGhDownloadReleaseAsset:
+    _SRC = GHReleaseAssetInfo(
+        owner="org", repo="project", tag="v1.0", filename="binary-linux-amd64"
+    )
+
+    def _make_release_resp(
+        self, asset_id: int = 99, filename: str = "binary-linux-amd64"
+    ) -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"assets": [{"id": asset_id, "name": filename}]}
+        return resp
+
+    def _make_download_resp(self, content: bytes = b"binary-content") -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.iter_content.return_value = [content]
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_downloads_asset_to_dest(self, tmp_path: Path) -> None:
+        dest = tmp_path / "binary"
+        release_resp = self._make_release_resp(asset_id=99)
+        download_resp = self._make_download_resp(b"binary-content")
+
+        with patch(
+            "kube_galaxy.pkg.utils.gh.requests.get",
+            side_effect=[release_resp, download_resp],
+        ):
+            gh_download_release_asset(self._SRC, dest)
+
+        assert dest.read_bytes() == b"binary-content"
+
+    def test_uses_correct_api_urls(self, tmp_path: Path) -> None:
+        dest = tmp_path / "binary"
+        release_resp = self._make_release_resp(asset_id=7)
+        download_resp = self._make_download_resp()
+        calls: list[str] = []
+
+        def fake_get(url: str, **kwargs: object) -> MagicMock:
+            calls.append(url)
+            return release_resp if "releases/tags" in url else download_resp
+
+        with patch("kube_galaxy.pkg.utils.gh.requests.get", side_effect=fake_get):
+            gh_download_release_asset(self._SRC, dest)
+
+        assert calls[0] == "https://api.github.com/repos/org/project/releases/tags/v1.0"
+        assert calls[1] == "https://api.github.com/repos/org/project/releases/assets/7"
+
+    def test_raises_component_error_when_release_fetch_fails(self, tmp_path: Path) -> None:
+        dest = tmp_path / "binary"
+        with (
+            patch(
+                "kube_galaxy.pkg.utils.gh.requests.get",
+                side_effect=requests_lib.RequestException("network error"),
+            ),
+            pytest.raises(ComponentError, match=r"Failed to fetch release 'v1\.0'"),
+        ):
+            gh_download_release_asset(self._SRC, dest)
+
+    def test_raises_component_error_when_asset_not_found(self, tmp_path: Path) -> None:
+        dest = tmp_path / "binary"
+        release_resp = MagicMock()
+        release_resp.raise_for_status = MagicMock()
+        release_resp.json.return_value = {"assets": [{"id": 1, "name": "other-file.tar.gz"}]}
+
+        with (
+            patch("kube_galaxy.pkg.utils.gh.requests.get", return_value=release_resp),
+            pytest.raises(ComponentError, match="Asset 'binary-linux-amd64' not found"),
+        ):
+            gh_download_release_asset(self._SRC, dest)
+
+    def test_error_lists_available_assets(self, tmp_path: Path) -> None:
+        dest = tmp_path / "binary"
+        release_resp = MagicMock()
+        release_resp.raise_for_status = MagicMock()
+        release_resp.json.return_value = {
+            "assets": [
+                {"id": 1, "name": "binary-windows-amd64"},
+                {"id": 2, "name": "binary-darwin-arm64"},
+            ]
+        }
+
+        with (
+            patch("kube_galaxy.pkg.utils.gh.requests.get", return_value=release_resp),
+            pytest.raises(ComponentError, match="binary-windows-amd64"),
+        ):
+            gh_download_release_asset(self._SRC, dest)
+
+    def test_raises_component_error_when_download_fails(self, tmp_path: Path) -> None:
+        dest = tmp_path / "binary"
+        release_resp = self._make_release_resp(asset_id=5)
+
+        def fake_get(url: str, **kwargs: object) -> MagicMock:
+            if "releases/tags" in url:
+                return release_resp
+            raise requests_lib.RequestException("connection refused")
+
+        with (
+            patch("kube_galaxy.pkg.utils.gh.requests.get", side_effect=fake_get),
+            pytest.raises(ComponentError, match="Failed to download asset 'binary-linux-amd64'"),
+        ):
+            gh_download_release_asset(self._SRC, dest)


### PR DESCRIPTION
This pull request adds support for downloading GitHub release assets (including from private repositories) by recognizing and handling GitHub release asset URLs in the `download_file` utility. It introduces new utilities for parsing and downloading release assets, updates the HTTP header logic for GitHub API requests, and adds comprehensive unit tests for these new features.

**GitHub Release Asset Download Support:**

* Added a new utility function `gh_match_release_asset` to detect and extract structured information from GitHub release asset URLs, returning a `GHReleaseAssetInfo` dataclass if matched.
* Implemented `gh_download_release_asset`, which uses the GitHub API and authentication token to securely download release assets, supporting private repositories and handling errors with informative messages.
* Updated `download_file` in `components.py` to route GitHub release asset URLs through the new matching and download logic, ensuring correct handling for these URLs. [[1]](diffhunk://#diff-0e8994b05cbd444821d4ec506c7bee9457249bf96b9004e78e2a0e4a8d8b8dc7L17-R21) [[2]](diffhunk://#diff-0e8994b05cbd444821d4ec506c7bee9457249bf96b9004e78e2a0e4a8d8b8dc7R56-R59)

**Improvements to GitHub API HTTP Header Handling:**

* Enhanced `gh_http_headers` to allow a custom `Accept` header and clarified precedence between `raw` and `accept` options, ensuring the correct headers are sent for different API requests.

**Testing Enhancements:**

* Added unit tests for the new GitHub release asset utilities, including matching, downloading, and error handling, as well as tests for the updated HTTP header logic and the new download routing in `download_file`. [[1]](diffhunk://#diff-0c682bb199a45c1633e0c6b751da9acc72e7275cce67fadf6396fd34abc26fceR1-R3) [[2]](diffhunk://#diff-0c682bb199a45c1633e0c6b751da9acc72e7275cce67fadf6396fd34abc26fceL18-R26) [[3]](diffhunk://#diff-0c682bb199a45c1633e0c6b751da9acc72e7275cce67fadf6396fd34abc26fceR445-R489) [[4]](diffhunk://#diff-eeaa05f994229bdbc733b07f10b555e41681c411127087a7aaad1796d0af6cb2R16-R22) [[5]](diffhunk://#diff-eeaa05f994229bdbc733b07f10b555e41681c411127087a7aaad1796d0af6cb2R359-R542)

These changes make it possible to fetch release assets from GitHub (including private ones) in a robust and testable way, improving the flexibility and reliability of component downloads.