### PR TITLE
Use manifest version of coredns and etcd if available

### DIFF
--- a/manifests/smoketest.yaml
+++ b/manifests/smoketest.yaml
@@ -146,7 +146,7 @@ components:
       repo:
         base-url: https://github.com/etcd-io/etcd
       source-format: "registry.k8s.io/etcd:v{{ release }}"
-      retag-format: "{{ mirror.base-url }}/etcd:{{ release }}-0"
+      retag-format: "{{ mirror.base-url }}/etcd:{{ release }}"
 
   # CoreDNS - required for cluster DNS
   - name: coredns
@@ -157,7 +157,7 @@ components:
       repo:
         base-url: https://github.com/coredns/coredns
       source-format: "registry.k8s.io/coredns/coredns:v{{ release }}"
-      retag-format: "{{ mirror.base-url }}/coredns:v{{ release }}"
+      retag-format: "{{ mirror.base-url }}/coredns:{{ release }}"
 
   # Calico - required for cluster networking
   - name: calico

--- a/src/kube_galaxy/pkg/components/kubeadm.py
+++ b/src/kube_galaxy/pkg/components/kubeadm.py
@@ -73,9 +73,14 @@ class Kubeadm(ClusterComponentBase):
         config["kubernetesVersion"] = self.manifest.kubernetes_version
         if registry_address:
             config["imageRepository"] = registry_address
-            config["dns"].update({"imageRepository": registry_address})
-            config["etcd"].update({"imageRepository": registry_address})
-
+        if etcd := self._ctx.components.get("etcd"):
+            release = etcd.config.release
+            info(f"  Setting etcd image tag to {release}")
+            config["etcd"]["local"].update({"imageTag": release})
+        if coredns := self._ctx.components.get("coredns"):
+            release = coredns.config.release
+            info(f"  Setting coredns image tag to {release}")
+            config["dns"].update({"imageTag": release})
         if len(self._ctx.control_plane_units) > 1:
             ## TODO: Support multiple control-plane nodes with a VIP
             config["controlPlaneEndpoint"] = "kube-galaxy:6443"


### PR DESCRIPTION
This pull request updates how image tags are handled for the `etcd` and `coredns` components in both the deployment manifests and the cluster configuration logic. The main goal is to ensure consistent and correct image tagging for these core Kubernetes components.

**Manifest improvements:**

* Standardized the `retag-format` for both `etcd` and `coredns` in `manifests/smoketest.yaml` to use the format `{{ mirror.base-url }}/<component>:{{ release }}` for consistency and to avoid redundant version prefixes. [[1]](diffhunk://#diff-e15d10e0c6b943086a8b11a81aad996d5cddd99b2ec8bf70c54f0180e71a590eL149-R149) [[2]](diffhunk://#diff-e15d10e0c6b943086a8b11a81aad996d5cddd99b2ec8bf70c54f0180e71a590eL160-R160)

**Cluster configuration logic:**

* Updated the `_update_cluster_config` method in `kubeadm.py` to explicitly set the `imageTag` for `etcd` and `coredns` based on their configured release, improving clarity and ensuring the correct image versions are used in cluster setup.