### PR TITLE
Include K8S_VERSION in environment for running tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ Inside `task.yaml` you can reference environment variables set by kube-galaxy:
 | `SYSTEM_ARCH`       | Raw `uname -m` architecture                   |
 | `IMAGE_ARCH`        | Container image architecture tag              |
 | `KUBECONFIG`        | Path to shared kubeconfig                     |
+| `K8S_VERSION`       | Versions of Kubernetes defined in manifest    |
+| `TEST_TIMEOUT_M`    | How long the task should take maximum in min  |
+| `TEST_TIMEOUT_S`    | How long the task should take maximum in sec  |
 
 Example `task.yaml`:
 

--- a/src/kube_galaxy/pkg/testing/spread.py
+++ b/src/kube_galaxy/pkg/testing/spread.py
@@ -130,13 +130,15 @@ def _component_kill_timeout(component: ComponentConfig) -> str | None:
     return None
 
 
-def _generate_orchestration_spread_yaml(components: list[ComponentConfig]) -> list[str]:
+def _generate_orchestration_spread_yaml(
+    components: list[ComponentConfig], k8s_version: str
+) -> list[str]:
     """
     Generate spread.yaml from template for component test orchestration.
 
     Args:
         components: List of components with spread tests
-        kubeconfig: Path to kubeconfig file (in shared directory)
+        k8s_version: Kubernetes version for conditional test logic
 
     Returns:
         List of component suites
@@ -159,6 +161,7 @@ def _generate_orchestration_spread_yaml(components: list[ComponentConfig]) -> li
                 "TEST_TIMEOUT_S": str(Timeouts.TEST_EXECUTION_TIMEOUT_S),
                 "TEST_TIMEOUT_M": str(Timeouts.TEST_EXECUTION_TIMEOUT_S // 60),
                 "KUBECONFIG": str(SystemPaths.local_kube_config()),
+                "K8S_VERSION": k8s_version,
             },
         }
 
@@ -286,7 +289,8 @@ def _run_component_tests(manifest: Manifest, work_dir: Path, test_type: str, deb
         raise ClusterError("Component validation failed")
 
     # Generate orchestration spread.yaml
-    component_suites = _generate_orchestration_spread_yaml(spread_components)
+    k8s_version = manifest.kubernetes_version
+    component_suites = _generate_orchestration_spread_yaml(spread_components, k8s_version)
 
     # Track test results
     test_results = []


### PR DESCRIPTION
This pull request introduces support for passing the Kubernetes version and test timeout values as environment variables to tasks, and updates the orchestration logic to propagate the Kubernetes version from the manifest to the test environment. This enables conditional test logic based on the Kubernetes version and improves test configuration flexibility.

**Environment variable enhancements:**

* Added documentation for new environment variables: `K8S_VERSION`, `TEST_TIMEOUT_M`, and `TEST_TIMEOUT_S` in the `README.md`, allowing tasks to reference the Kubernetes version and test timeout values.
* Updated the orchestration logic in `_generate_orchestration_spread_yaml` to inject the `K8S_VERSION` environment variable into each component suite, using the version from the manifest.

**Codebase updates for Kubernetes version propagation:**

* Modified `_generate_orchestration_spread_yaml` to accept a `k8s_version` argument, ensuring the correct version is passed through the orchestration process.
* Updated `_run_component_tests` to extract the Kubernetes version from the manifest and pass it to `_generate_orchestration_spread_yaml`, ensuring consistency across the testing workflow.