### PR TITLE
Use pause container pulled into registry

### DIFF
--- a/src/kube_galaxy/pkg/components/containerd.py
+++ b/src/kube_galaxy/pkg/components/containerd.py
@@ -89,9 +89,9 @@ class Containerd(ComponentBase):
             if (
                 install.method
                 in [InstallMethod.CONTAINER_IMAGE_ARCHIVE, InstallMethod.CONTAINER_IMAGE]
-                and install.source_format
+                and pause.install_path
             ):
-                image_format = pause.config.installation.source_format
+                image_format = pause.install_path
             # Otherwise construct from release version
             elif pause.config.release:
                 image_format = f"{URLs.REGISTRY_K8S_IO}/pause:{pause.config.release}"

--- a/src/kube_galaxy/pkg/components/strategies/container_image.py
+++ b/src/kube_galaxy/pkg/components/strategies/container_image.py
@@ -51,6 +51,7 @@ def _download(comp: ComponentBase) -> None:
         mirror_path = f"{parts[1]}:{source_tag}" if len(parts) > 1 else image_source
         info(f"  Preloading image into registry mirror: {image_source} -> {mirror_path}")
         mirror.preload(f"docker://{image_source}", mirror_path)
+        comp.install_path = f"{mirror.registry_address()}/{mirror_path}"
     else:
         info(f"  No registry mirror configured; skipping preload for {image_source}")
 
@@ -60,6 +61,7 @@ def _download(comp: ComponentBase) -> None:
         retag_path = f"{parts[1]}:{retag_tag}" if len(parts) > 1 else image_retag
         info(f"  Retagging image in registry mirror: {mirror_path} -> {retag_path}")
         mirror.retag(mirror_path, retag_path)
+        comp.install_path = f"{mirror.registry_address()}/{retag_path}"
 
 
 _ContainerImageInstallStrategy = _InstallStrategy(download=_download)


### PR DESCRIPTION
This pull request introduces several updates related to image installation in the `kube-galaxy` project. The most significant changes include enhanced tracking of container image installation paths, which improves downstream component behavior.

**Container Image Installation Improvements:**

* The `_download` function in `container_image.py` now sets the `install_path` attribute on the component after preloading or retagging an image, ensuring the component knows the exact image location in the registry mirror. [[1]](diffhunk://#diff-40dc52bdf87056321e2548d9f66bbb72f7016b7adbe3cb25660a6dd2c24d61a1R54) [[2]](diffhunk://#diff-40dc52bdf87056321e2548d9f66bbb72f7016b7adbe3cb25660a6dd2c24d61a1R64)
* The `_get_pause_image` method in `containerd.py` now prefers `pause.install_path` (set during installation) over `source_format`, ensuring the correct image path is used when constructing the pause image reference.