### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   call-inclusive-naming-check:
     name: Inclusive Naming
-    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@main
+    uses: canonical/inclusive-naming/.github/workflows/woke.yaml@7aa0f7a606f182bd03a7adb28e0d710216101ca5 # main
     permissions:
       contents: read
       checks: write
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Astral UV
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -109,18 +109,18 @@ jobs:
 
       # ---- Checkout local directory for manifests and components ----
       - name: Checkout manifests repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ inputs.manifests-repo }}
           ref: ${{ inputs.manifests-ref }}
 
       - name: Setup Astral UV
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.12"
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ">=1.22"
 
@@ -128,10 +128,10 @@ jobs:
         run: go install github.com/canonical/spread/cmd/spread@latest
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@d492474f6c8ceed1b716bb34c8f575a428871c70 # main
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@7fecadc5a536c19dab9bfa27ca6ed097bb294a7c # v5
         with:
           version: "latest"
 
@@ -141,14 +141,14 @@ jobs:
           sudo apt-get install -y skopeo
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: cdkbot
           password: ${{ secrets.REPO_ACCESS_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload Debug Logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: debug-logs-${{ steps.setup-cluster.outputs.artifact-name || hashFiles(matrix.manifest-file) }}
           path: debug-logs/
@@ -229,7 +229,7 @@ jobs:
 
       - name: Setup upterm session for debugging
         if: failure() && github.event_name == 'pull_request'
-        uses: owenthereal/action-upterm@v1
+        uses: owenthereal/action-upterm@03a90e8bc8d4883773d048976a3e53347ab4d6dd # v1
         timeout-minutes: 5
         with:
           limit-access-to-actor: true

--- a/.github/workflows/reusable-validate-manifests.yml
+++ b/.github/workflows/reusable-validate-manifests.yml
@@ -34,27 +34,27 @@ jobs:
       # Internal call (manifests live in this repo): use the caller's own context.
       - name: Checkout kube-galaxy-test (internal)
         if: inputs.manifests-repo == ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # External call (manifests live in a separate repo): check out
       # canonical/kube-galaxy-test at the caller-specified ref.
       - name: Checkout kube-galaxy-test (external)
         if: inputs.manifests-repo != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: canonical/kube-galaxy-test
           ref: ${{ inputs.kube-galaxy-ref }}
 
       - name: Checkout manifests repo
         if: inputs.manifests-repo != ''
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ inputs.manifests-repo }}
           ref: ${{ inputs.manifests-ref }}
           path: _manifests
 
       - name: Setup Astral UV
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Astral UV
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Pin all GitHub Actions to their commit SHAs to improve supply chain security.

This prevents:
- Compromised tags from injecting malicious code
- Unexpected behavior from mutable references
- Supply chain attacks via action tag manipulation

Related: KU-5612