### PR TITLE
feat: added support for overlays in cluster test

### DIFF
--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -6,7 +6,7 @@ on:
       manifests-json:
         description: >
           JSON array of manifest objects, e.g.
-          [{"manifest-file": "manifests/baseline-k8s-1.35.yaml", "overlays": [], "provider-image": "ubuntu:24.04"}]
+          [{"manifest-file": "manifests/baseline-k8s-1.35.yaml", "overlays": ["manifests/overlays/ubuntu/ubuntu-24.04.yaml"]}]
         type: string
         required: true
       manifests-repo:
@@ -165,7 +165,7 @@ jobs:
         run: |
           echo "## Test Configuration"
           echo "- **Manifest**: ${{ matrix.manifest-file }}"
-          echo "- **Provider image**: ${{ matrix.provider-image || 'default' }}"
+          echo "- **Overlays**: ${{ toJson(matrix.overlays) }}"
           echo "- **Runner**: ${{ inputs.runs-on }}"
           echo "- **Timeout**: ${{ inputs.timeout-minutes }} minutes"
 
@@ -180,9 +180,10 @@ jobs:
         run: |
           # Sanitized name for artifact uploads
           ARTIFACT_NAME=$(echo "${{ matrix.manifest-file }}" | sed 's/\//-/g')
-          if [ -n "${{ matrix.provider-image }}" ]; then
-            ARTIFACT_NAME="${ARTIFACT_NAME}-$(echo '${{ matrix.provider-image }}' | tr ':/' '--')"
-          fi
+          # Append overlay basenames to make artifact names unique per matrix entry
+          for ov in $(echo '${{ toJson(matrix.overlays) }}' | jq -r '.[]? // empty'); do
+            ARTIFACT_NAME="${ARTIFACT_NAME}-$(basename "$ov" .yaml)"
+          done
           echo "artifact-name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
           OVERLAY_FLAGS=""
@@ -190,12 +191,7 @@ jobs:
             OVERLAY_FLAGS="$OVERLAY_FLAGS --overlay $ov"
           done
 
-          PROVIDER_IMAGE_FLAG=""
-          if [ -n "${{ matrix.provider-image }}" ]; then
-            PROVIDER_IMAGE_FLAG="--provider-image ${{ matrix.provider-image }}"
-          fi
-
-          kube-galaxy setup ${{ matrix.manifest-file }} $OVERLAY_FLAGS $PROVIDER_IMAGE_FLAG
+          kube-galaxy setup ${{ matrix.manifest-file }} $OVERLAY_FLAGS
 
       - name: Verify Cluster Health
         shell: bash

--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -6,7 +6,7 @@ on:
       manifests-json:
         description: >
           JSON array of manifest objects, e.g.
-          [{"manifest-file": "manifests/baseline-k8s-1.35.yaml", "overlays": []}]
+          [{"manifest-file": "manifests/baseline-k8s-1.35.yaml", "overlays": [], "provider-image": "ubuntu:24.04"}]
         type: string
         required: true
       manifests-repo:
@@ -165,7 +165,8 @@ jobs:
         run: |
           echo "## Test Configuration"
           echo "- **Manifest**: ${{ matrix.manifest-file }}"
-          echo "- **Runner**: ubuntu-latest"
+          echo "- **Provider image**: ${{ matrix.provider-image || 'default' }}"
+          echo "- **Runner**: ${{ inputs.runs-on }}"
           echo "- **Timeout**: ${{ inputs.timeout-minutes }} minutes"
 
       - name: Setup Cluster
@@ -179,6 +180,9 @@ jobs:
         run: |
           # Sanitized name for artifact uploads
           ARTIFACT_NAME=$(echo "${{ matrix.manifest-file }}" | sed 's/\//-/g')
+          if [ -n "${{ matrix.provider-image }}" ]; then
+            ARTIFACT_NAME="${ARTIFACT_NAME}-$(echo '${{ matrix.provider-image }}' | tr ':/' '--')"
+          fi
           echo "artifact-name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
 
           OVERLAY_FLAGS=""
@@ -186,7 +190,12 @@ jobs:
             OVERLAY_FLAGS="$OVERLAY_FLAGS --overlay $ov"
           done
 
-          kube-galaxy setup ${{ matrix.manifest-file }} $OVERLAY_FLAGS
+          PROVIDER_IMAGE_FLAG=""
+          if [ -n "${{ matrix.provider-image }}" ]; then
+            PROVIDER_IMAGE_FLAG="--provider-image ${{ matrix.provider-image }}"
+          fi
+
+          kube-galaxy setup ${{ matrix.manifest-file }} $OVERLAY_FLAGS $PROVIDER_IMAGE_FLAG
 
       - name: Verify Cluster Health
         shell: bash

--- a/src/kube_galaxy/cli.py
+++ b/src/kube_galaxy/cli.py
@@ -24,6 +24,11 @@ _OVERLAY_OPTION = typer.Option(
         "Repeat to apply multiple overlays in order (later overlays win)."
     ),
 )
+_PROVIDER_IMAGE_OPTION = typer.Option(
+    None,
+    "--provider-image",
+    help="Override the provider base image (e.g. 'ubuntu:22.04').",
+)
 _MANIFEST_RECOVERY_OPTION = typer.Option(
     None,
     "--manifest",
@@ -139,6 +144,7 @@ def setup_cmd(
         help="Merge the 'kube-galaxy' context into ~/.kube/config without prompting",
     ),
     overlays: list[str] = _OVERLAY_OPTION,
+    provider_image: str | None = _PROVIDER_IMAGE_OPTION,
 ) -> None:
     """Provision a cluster from a manifest file.
 
@@ -146,8 +152,14 @@ def setup_cmd(
         kube-galaxy setup manifests/baseline-k8s-1.35.yaml
         kube-galaxy setup manifests/baseline-k8s-1.35.yaml --update-kubeconfig
         kube-galaxy setup manifests/baseline-k8s-1.35.yaml --overlay overlays/tweak.yaml
+        kube-galaxy setup manifests/baseline-k8s-1.35.yaml --provider-image ubuntu:22.04
     """
-    setup.setup(manifest, update_kubeconfig=update_kubeconfig, overlays=overlays or None)
+    setup.setup(
+        manifest,
+        update_kubeconfig=update_kubeconfig,
+        overlays=overlays or None,
+        provider_image=provider_image,
+    )
 
 
 @app.command(name="status")

--- a/src/kube_galaxy/cmd/setup.py
+++ b/src/kube_galaxy/cmd/setup.py
@@ -19,6 +19,7 @@ def setup(
     manifest_path: str,
     update_kubeconfig: bool = False,
     overlays: list[str] | None = None,
+    provider_image: str | None = None,
 ) -> None:
     """Provision a Kubernetes cluster from a manifest file.
 
@@ -31,8 +32,10 @@ def setup(
         overlays: Optional ordered list of overlay YAML file paths to
             deep-merge on top of *manifest_path* before provisioning.  Later
             overlays take precedence over earlier ones.
+        provider_image: Optional override for the provider base image
+            (e.g. ``ubuntu:22.04``).  Applied after overlays.
     """
-    active = create_active_manifest(manifest_path, overlays)
+    active = create_active_manifest(manifest_path, overlays, provider_image=provider_image)
     setup_cluster(active)
     _handle_kubeconfig_adjustment(update_kubeconfig)
 

--- a/src/kube_galaxy/pkg/utils/paths.py
+++ b/src/kube_galaxy/pkg/utils/paths.py
@@ -29,7 +29,12 @@ def ensure_dir(path: Path) -> Path:
     return path
 
 
-def create_active_manifest(manifest_path: str, overlays: Sequence[str] | None = None) -> Path:
+def create_active_manifest(
+    manifest_path: str,
+    overlays: Sequence[str] | None = None,
+    *,
+    provider_image: str | None = None,
+) -> Path:
     """Write the active-manifest file, merging any overlays on top of the base.
 
     When *overlays* are provided they are deep-merged onto *manifest_path* in
@@ -42,6 +47,8 @@ def create_active_manifest(manifest_path: str, overlays: Sequence[str] | None = 
     Args:
         manifest_path: Path (relative or absolute) to the base manifest file.
         overlays: Optional ordered sequence of overlay YAML file paths.
+        provider_image: Optional override for the provider base image
+            (e.g. ``ubuntu:22.04``).  Applied after overlays.
 
     Returns:
         The :class:`~pathlib.Path` of the written active-manifest file.
@@ -55,6 +62,9 @@ def create_active_manifest(manifest_path: str, overlays: Sequence[str] | None = 
             merged = yaml.safe_load(f)
         manifest = deserialize_manifest(merged, base)
         validate_manifest(manifest)
+
+    if provider_image:
+        merged.setdefault("provider", {})["image"] = provider_image
 
     active = SystemPaths.active_manifest_path()
     active.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -212,7 +212,10 @@ class TestSetupCmd:
             result = _invoke("setup", "manifests/baseline-k8s-1.35.yaml")
         assert result.exit_code == 0
         mock_setup.assert_called_once_with(
-            "manifests/baseline-k8s-1.35.yaml", update_kubeconfig=False, overlays=None
+            "manifests/baseline-k8s-1.35.yaml",
+            update_kubeconfig=False,
+            overlays=None,
+            provider_image=None,
         )
 
     def test_overlay_option_forwarded(self) -> None:
@@ -228,4 +231,21 @@ class TestSetupCmd:
             "manifests/baseline-k8s-1.35.yaml",
             update_kubeconfig=False,
             overlays=["overlays/extra.yaml"],
+            provider_image=None,
+        )
+
+    def test_provider_image_option_forwarded(self) -> None:
+        with patch("kube_galaxy.cmd.setup.setup") as mock_setup:
+            result = _invoke(
+                "setup",
+                "manifests/baseline-k8s-1.35.yaml",
+                "--provider-image",
+                "ubuntu:22.04",
+            )
+        assert result.exit_code == 0
+        mock_setup.assert_called_once_with(
+            "manifests/baseline-k8s-1.35.yaml",
+            update_kubeconfig=False,
+            overlays=None,
+            provider_image="ubuntu:22.04",
         )


### PR DESCRIPTION
This PR adds support for using overlays such as modifying the base image into KGT.


Initially, there was a plan to expose a `provider-image` matrix key in the manifest JSON, but this has been changed in favor of using overlays instead. However, as a leftover from that work, a flag to the setup args to allow the user to specify what base image should be used for the node VMs in KGT lxd deployment is still there for QoL in manual usage.