### PR TITLE
feat: add Helm install strategy for cluster components

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,31 @@ installation:
   source-format: "{{ repo.base-url }}/releases/download/v{{ release }}/tool-{{ release }}-linux-{{ arch }}.tar.gz"
 ```
 
+### Helm Installation Method
+
+Components can be installed via Helm charts using `method: helm`. The `helm`
+binary must be present as a `binary-archive` component earlier in the manifest.
+
+| Field         | Description                                                                 |
+|---------------|-----------------------------------------------------------------------------|
+| `method`      | Set to `helm`                                                               |
+| `helm-repo`   | `true` to use a chart repository; omit/`false` to download a `.tgz` archive |
+| `repo.base-url` | Chart repo URL (when `helm-repo: true`) or base URL for archive download  |
+| `source-format` | Chart reference `<repo>/<chart>` (repo mode) or URL to `.tgz` (archive mode) |
+
+**Example (archive):**
+
+```yaml
+- name: calico
+  category: projectcalico/calico
+  release: "3.32.0"
+  installation:
+    method: helm
+    repo:
+      base-url: https://github.com/projectcalico/calico
+    source-format: "{{ repo.base-url }}/releases/download/v{{ release }}/tigera-operator-v{{ release }}.tgz"
+```
+
 ### GitHub Actions Artifact Sources
 
 A component whose test suite is uploaded as a GitHub Actions artifact in a

--- a/manifests/smoketest.yaml
+++ b/manifests/smoketest.yaml
@@ -86,6 +86,16 @@ components:
         base-url: https://github.com/kubernetes/kubernetes
       source-format: "https://dl.k8s.io/release/v{{ release }}/bin/linux/{{ arch }}/kubectl"
 
+  - name: helm
+    category: helm/helm
+    release: "4.1.4"
+    installation:
+      method: binary-archive
+      bin-path: "./linux-{{ arch }}/helm"
+      repo:
+        base-url: https://github.com/helm/helm
+      source-format: "https://get.helm.sh/helm-v{{ release }}-linux-{{ arch }}.tar.gz"
+
   # Kubernetes control plane components
   - name: kube-apiserver
     category: kubernetes/kubernetes

--- a/manifests/smoketest.yaml
+++ b/manifests/smoketest.yaml
@@ -170,14 +170,23 @@ components:
       retag-format: "{{ mirror.base-url }}/coredns:{{ release }}"
 
   # Calico - required for cluster networking
-  - name: calico
+  - name: calico-crds
     category: projectcalico/calico
-    release:  &calico-version "3.30.6"
+    release: &calico-version "3.32.0"
     installation:
-      method: container-manifest
+      method: helm
       repo:
         base-url: https://github.com/projectcalico/calico
-      source-format: "https://api.github.com/repos/projectcalico/calico/contents/manifests/calico.yaml?ref=v{{ release }}"
+      source-format: "{{ repo.base-url }}/releases/download/v{{ release }}/crd.projectcalico.org.v1-v{{ release }}.tgz"
+
+  - name: calico
+    category: projectcalico/calico
+    release: *calico-version
+    installation:
+      method: helm
+      repo:
+        base-url: https://github.com/projectcalico/calico
+      source-format: "{{ repo.base-url }}/releases/download/v{{ release }}/tigera-operator-v{{ release }}.tgz"
 
   # CSI Driver Host Path - lightweight CSI for testing
   - name: csi-hostpath

--- a/src/kube_galaxy/pkg/components/_base.py
+++ b/src/kube_galaxy/pkg/components/_base.py
@@ -98,6 +98,7 @@ class ComponentBase:
         self.install_path: str | None = None  # path to root installed bin
         # for InstallMethod ContainerManifest
         self.manifest_path: Path | None = None  # path to downloaded manifest file
+        self.chart_path: Path | None = None  # path to downloaded chart archive (for Helm)
 
         install_method = config.installation.method
         if install_method not in _INSTALL_STRATEGIES:

--- a/src/kube_galaxy/pkg/components/strategies/__init__.py
+++ b/src/kube_galaxy/pkg/components/strategies/__init__.py
@@ -13,6 +13,7 @@ from .binary_archive import _BinaryArchiveInstallStrategy
 from .container_image import _ContainerImageInstallStrategy
 from .container_image_archive import _ContainerImageArchiveInstallStrategy
 from .container_manifest import _ContainerManifestInstallStrategy
+from .helm import _HelmInstallStrategy
 from .spread import _SpreadTestStrategy
 
 _INSTALL_STRATEGIES: dict[InstallMethod, _InstallStrategy] = {
@@ -21,6 +22,7 @@ _INSTALL_STRATEGIES: dict[InstallMethod, _InstallStrategy] = {
     InstallMethod.CONTAINER_IMAGE_ARCHIVE: _ContainerImageArchiveInstallStrategy,
     InstallMethod.CONTAINER_IMAGE: _ContainerImageInstallStrategy,
     InstallMethod.CONTAINER_MANIFEST: _ContainerManifestInstallStrategy,
+    InstallMethod.HELM: _HelmInstallStrategy,
     InstallMethod.NONE: _InstallStrategy(),
 }
 

--- a/src/kube_galaxy/pkg/components/strategies/helm.py
+++ b/src/kube_galaxy/pkg/components/strategies/helm.py
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING
 import yaml
 
 from kube_galaxy.pkg.utils.client import kubectl
+from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
 from kube_galaxy.pkg.utils.helm import (
     helm,
     helm_install_from_archive,
     helm_install_from_repo,
     helm_repo_add,
 )
-from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
 
 from ._base import _fetch_to_temp, _InstallStrategy, only_lead_control_plane
 

--- a/src/kube_galaxy/pkg/components/strategies/helm.py
+++ b/src/kube_galaxy/pkg/components/strategies/helm.py
@@ -25,18 +25,13 @@ if TYPE_CHECKING:
 def _download(comp: ComponentBase) -> None:
     """Download helm chart artifacts.
 
-    When helm_repo is True, adds the chart repository from repo.base_url so
-    the chart reference in source_format can be resolved during bootstrap.
-    Otherwise, downloads the chart archive (.tgz) from the rendered source_format URL.
+    When helm_repo is False, downloads the chart archive (.tgz) from the
+    rendered source_format URL. When helm_repo is True, nothing is done here;
+    the repo is added during bootstrap when the helm binary is available.
     """
     install_cfg = comp.config.installation
 
-    if install_cfg.helm_repo:
-        # source_format is a chart ref like "projectcalico/tigera-operator"
-        # repo name is the prefix before "/"
-        repo_name = install_cfg.source_format.split("/")[0]
-        helm_repo_add(comp.unit, repo_name, install_cfg.repo.base_url)
-    else:
+    if not install_cfg.helm_repo:
         comp.chart_path = _fetch_to_temp(comp)
 
 
@@ -44,15 +39,16 @@ def _download(comp: ComponentBase) -> None:
 def _bootstrap(comp: ComponentBase) -> None:
     """Install the helm chart.
 
-    Uses helm_install_from_repo when helm_repo is True (chart reference from
-    an added repository), otherwise installs from the locally downloaded
-    chart archive.
+    When helm_repo is True, adds the chart repository and installs the chart
+    by reference. Otherwise installs from the locally downloaded chart archive.
     """
     comp_name = comp.config.name
     install_cfg = comp.config.installation
 
     try:
         if install_cfg.helm_repo:
+            repo_name = install_cfg.source_format.split("/")[0]
+            helm_repo_add(comp.unit, repo_name, install_cfg.repo.base_url)
             helm_install_from_repo(comp.unit, comp_name, install_cfg.source_format)
         else:
             if not comp.chart_path or not comp.chart_path.exists():

--- a/src/kube_galaxy/pkg/components/strategies/helm.py
+++ b/src/kube_galaxy/pkg/components/strategies/helm.py
@@ -1,0 +1,115 @@
+"""Install hooks for InstallMethod.HELM."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from kube_galaxy.pkg.utils.client import kubectl
+from kube_galaxy.pkg.utils.helm import (
+    helm,
+    helm_install_from_archive,
+    helm_install_from_repo,
+    helm_repo_add,
+)
+from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
+
+from ._base import _fetch_to_temp, _InstallStrategy, only_lead_control_plane
+
+if TYPE_CHECKING:
+    from kube_galaxy.pkg.components._base import ComponentBase
+
+
+@only_lead_control_plane
+def _download(comp: ComponentBase) -> None:
+    """Download helm chart artifacts.
+
+    When helm_repo is True, adds the chart repository from repo.base_url so
+    the chart reference in source_format can be resolved during bootstrap.
+    Otherwise, downloads the chart archive (.tgz) from the rendered source_format URL.
+    """
+    install_cfg = comp.config.installation
+
+    if install_cfg.helm_repo:
+        # source_format is a chart ref like "projectcalico/tigera-operator"
+        # repo name is the prefix before "/"
+        repo_name = install_cfg.source_format.split("/")[0]
+        helm_repo_add(comp.unit, repo_name, install_cfg.repo.base_url)
+    else:
+        comp.chart_path = _fetch_to_temp(comp)
+
+
+@only_lead_control_plane
+def _bootstrap(comp: ComponentBase) -> None:
+    """Install the helm chart.
+
+    Uses helm_install_from_repo when helm_repo is True (chart reference from
+    an added repository), otherwise installs from the locally downloaded
+    chart archive.
+    """
+    comp_name = comp.config.name
+    install_cfg = comp.config.installation
+
+    try:
+        if install_cfg.helm_repo:
+            helm_install_from_repo(comp.unit, comp_name, install_cfg.source_format)
+        else:
+            if not comp.chart_path or not comp.chart_path.exists():
+                raise ComponentError(
+                    f"{comp_name} chart not downloaded. Run download hook first."
+                )
+            helm_install_from_archive(comp.unit, comp_name, comp.chart_path)
+    except ClusterError as e:
+        raise ComponentError(f"Failed to install helm chart for {comp_name}") from e
+
+
+@only_lead_control_plane
+def _verify(comp: ComponentBase) -> None:
+    """Verify the helm release is deployed and all workloads are rolled out.
+
+    Retrieves the rendered manifests from the helm release and checks rollout
+    status for all Deployments, DaemonSets, and StatefulSets.
+    """
+    comp_name = comp.config.name
+
+    # Get the rendered manifests that helm actually deployed
+    try:
+        result = helm(comp.unit, "get", "manifest", comp_name, check=True)
+    except Exception as e:
+        raise ComponentError(f"Failed to get helm manifest for {comp_name}") from e
+
+    docs = [doc for doc in yaml.safe_load_all(result.stdout) if isinstance(doc, dict)]
+
+    for doc in docs:
+        kind = doc.get("kind")
+        if kind not in ("Deployment", "DaemonSet", "StatefulSet"):
+            continue
+
+        metadata = doc.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+
+        name = metadata.get("name")
+        if not isinstance(name, str):
+            continue
+
+        namespace = metadata.get("namespace", "default")
+        if not isinstance(namespace, str):
+            namespace = "default"
+
+        kubectl(
+            comp.unit,
+            "rollout",
+            "status",
+            f"{kind.lower()}/{name.lower()}",
+            "-n",
+            namespace.lower(),
+            timeout=comp.BOOTSTRAP_TIMEOUT,
+        )
+
+
+_HelmInstallStrategy = _InstallStrategy(
+    download=_download, bootstrap=_bootstrap, verify=_verify
+)
+

--- a/src/kube_galaxy/pkg/manifest/loader.py
+++ b/src/kube_galaxy/pkg/manifest/loader.py
@@ -161,6 +161,7 @@ def deserialize_manifest(data: dict[str, Any], path: Path) -> Manifest:
             retag_format=install_data.get("retag-format", ""),
             bin_path=install_data.get("bin-path", "./*"),
             repo=_parse_repo(install_data.get("repo"), comp_name),
+            helm_repo=install_data.get("helm-repo", False),
         )
 
         # Parse test block (mirrors install config; absent / false → method: none)

--- a/src/kube_galaxy/pkg/manifest/models.py
+++ b/src/kube_galaxy/pkg/manifest/models.py
@@ -31,7 +31,7 @@ class InstallMethod(StrEnum):
     CONTAINER_IMAGE = "container-image"  # Container image from registry
     CONTAINER_IMAGE_ARCHIVE = "container-image-archive"  # Container image in tar archive
     CONTAINER_MANIFEST = "container-manifest"  # Kubernetes YAML manifest file
-    HELM = "helm" # Helm char from a chart repository
+    HELM = "helm"  # Helm chart from a chart repository
     NONE = "none"  # No installation, component has no installable artifacts
 
 

--- a/src/kube_galaxy/pkg/manifest/models.py
+++ b/src/kube_galaxy/pkg/manifest/models.py
@@ -67,7 +67,7 @@ class InstallConfig:
     retag_format: str  # e.g. format string for retagging container images to pull through registry
     bin_path: str  # Default path inside archive where binaries
     repo: RepoInfo = field(default_factory=RepoInfo)  # Repository for this install artefact
-    helm_repo: bool = False  # If True, source_format is a chart ref and repo.base_url is the helm repo URL
+    helm_repo: bool = False  # Use chart repo instead of archive
 
 
 @dataclass

--- a/src/kube_galaxy/pkg/manifest/models.py
+++ b/src/kube_galaxy/pkg/manifest/models.py
@@ -31,6 +31,7 @@ class InstallMethod(StrEnum):
     CONTAINER_IMAGE = "container-image"  # Container image from registry
     CONTAINER_IMAGE_ARCHIVE = "container-image-archive"  # Container image in tar archive
     CONTAINER_MANIFEST = "container-manifest"  # Kubernetes YAML manifest file
+    HELM = "helm" # Helm char from a chart repository
     NONE = "none"  # No installation, component has no installable artifacts
 
 

--- a/src/kube_galaxy/pkg/manifest/models.py
+++ b/src/kube_galaxy/pkg/manifest/models.py
@@ -67,6 +67,7 @@ class InstallConfig:
     retag_format: str  # e.g. format string for retagging container images to pull through registry
     bin_path: str  # Default path inside archive where binaries
     repo: RepoInfo = field(default_factory=RepoInfo)  # Repository for this install artefact
+    helm_repo: bool = False  # If True, source_format is a chart ref and repo.base_url is the helm repo URL
 
 
 @dataclass

--- a/src/kube_galaxy/pkg/utils/helm.py
+++ b/src/kube_galaxy/pkg/utils/helm.py
@@ -62,7 +62,7 @@ def helm_install_from_repo(unit: Unit, release: str, chart: str) -> None:
     """
     try:
         info(f"Installing helm release: {release} (chart: {chart})")
-        helm(unit, "install", release, chart, check=True)
+        helm(unit, "install", release, chart, "--create-namespace", check=True)
         success(f"Helm release installed: {release}")
     except ShellError as exc:
         raise ClusterError(f"Failed to install helm release {release}: {exc}") from exc
@@ -85,27 +85,9 @@ def helm_install_from_archive(unit: Unit, release: str, chart_path: Path) -> Non
     try:
         info(f"Installing helm release: {release} (chart: {chart_path.name})")
         unit.put(chart_path, remote_chart)
-        helm(unit, "install", release, remote_chart, check=True)
+        helm(unit, "install", release, remote_chart, "--create-namespace", check=True)
         success(f"Helm release installed: {release}")
     except ShellError as exc:
         raise ClusterError(f"Failed to install helm release {release}: {exc}") from exc
     finally:
         unit.run(["rm", "-f", remote_chart], check=False)
-
-
-def helm_uninstall(unit: Unit, release: str) -> None:
-    """Uninstall a helm release.
-
-    Args:
-        unit: Unit on which to run helm
-        release: Release name to uninstall
-
-    Raises:
-        ClusterError: If helm uninstall fails
-    """
-    try:
-        info(f"Uninstalling helm release: {release}")
-        helm(unit, "uninstall", release, check=True)
-        success(f"Helm release uninstalled: {release}")
-    except ShellError as exc:
-        raise ClusterError(f"Failed to uninstall helm release {release}: {exc}") from exc

--- a/src/kube_galaxy/pkg/utils/helm.py
+++ b/src/kube_galaxy/pkg/utils/helm.py
@@ -1,0 +1,111 @@
+"""Helm client operations wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from kube_galaxy.pkg.literals import SystemPaths
+from kube_galaxy.pkg.units import RunResult, Unit
+from kube_galaxy.pkg.utils.errors import ClusterError
+from kube_galaxy.pkg.utils.logging import info, success
+from kube_galaxy.pkg.utils.shell import ShellError
+
+
+def helm(unit: Unit, *cmd: str, **kwargs: Any) -> RunResult:
+    """Run a helm command on the unit.
+
+    Args:
+        unit: Unit on which to run helm
+        *cmd: helm subcommand and arguments
+        **kwargs: Passed through to unit.run() (check, timeout, privileged)
+
+    Returns:
+        RunResult from the command execution
+    """
+    env = {"KUBECONFIG": str(SystemPaths.kube_config())}
+    return unit.run(["helm", *cmd], env=env, **kwargs)
+
+
+def helm_repo_add(unit: Unit, name: str, url: str) -> None:
+    """Add a helm chart repository and update the repo index.
+
+    Uses --force-update so repeated calls are idempotent.
+
+    Args:
+        unit: Unit on which to run helm
+        name: Repository name (e.g. "projectcalico")
+        url: Repository URL (e.g. "https://docs.tigera.io/calico/charts")
+
+    Raises:
+        ClusterError: If repo add fails
+    """
+    try:
+        info(f"Adding helm repo: {name} ({url})")
+        helm(unit, "repo", "add", name, url, "--force-update", check=True)
+        helm(unit, "repo", "update", check=True)
+        success(f"Helm repo added: {name}")
+    except ShellError as exc:
+        raise ClusterError(f"Failed to add helm repo {name}: {exc}") from exc
+
+
+def helm_install_from_repo(unit: Unit, release: str, chart: str) -> None:
+    """Install a helm chart from a previously added repository.
+
+    Args:
+        unit: Unit on which to run helm
+        release: Release name (e.g. "calico")
+        chart: Chart reference (e.g. "projectcalico/tigera-operator")
+
+    Raises:
+        ClusterError: If helm install fails
+    """
+    try:
+        info(f"Installing helm release: {release} (chart: {chart})")
+        helm(unit, "install", release, chart, check=True)
+        success(f"Helm release installed: {release}")
+    except ShellError as exc:
+        raise ClusterError(f"Failed to install helm release {release}: {exc}") from exc
+
+
+def helm_install_from_archive(unit: Unit, release: str, chart_path: Path) -> None:
+    """Install a helm chart from a local chart archive.
+
+    Pushes the chart archive to the unit and runs helm install from it.
+
+    Args:
+        unit: Unit on which to run helm
+        release: Release name (e.g. "calico")
+        chart_path: Local path to the chart archive (.tgz)
+
+    Raises:
+        ClusterError: If helm install fails
+    """
+    remote_chart = "/tmp/helm_chart.tgz"
+    try:
+        info(f"Installing helm release: {release} (chart: {chart_path.name})")
+        unit.put(chart_path, remote_chart)
+        helm(unit, "install", release, remote_chart, check=True)
+        success(f"Helm release installed: {release}")
+    except ShellError as exc:
+        raise ClusterError(f"Failed to install helm release {release}: {exc}") from exc
+    finally:
+        unit.run(["rm", "-f", remote_chart], check=False)
+
+
+def helm_uninstall(unit: Unit, release: str) -> None:
+    """Uninstall a helm release.
+
+    Args:
+        unit: Unit on which to run helm
+        release: Release name to uninstall
+
+    Raises:
+        ClusterError: If helm uninstall fails
+    """
+    try:
+        info(f"Uninstalling helm release: {release}")
+        helm(unit, "uninstall", release, check=True)
+        success(f"Helm release uninstalled: {release}")
+    except ShellError as exc:
+        raise ClusterError(f"Failed to uninstall helm release {release}: {exc}") from exc

--- a/tests/unit/components/test_helm.py
+++ b/tests/unit/components/test_helm.py
@@ -1,6 +1,5 @@
 """Unit tests for helm install method."""
 
-from pathlib import Path
 
 import pytest
 
@@ -15,7 +14,8 @@ from kube_galaxy.pkg.manifest.models import (
     RepoInfo,
 )
 from kube_galaxy.pkg.units._base import RunResult
-from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
+from kube_galaxy.pkg.utils.errors import ComponentError
+from kube_galaxy.pkg.utils.shell import ShellError
 from tests.unit.components.conftest import MockUnit
 
 
@@ -51,7 +51,10 @@ def helm_archive_config():
     repo = RepoInfo(base_url="https://github.com/org/chart")
     install = InstallConfig(
         method=InstallMethod.HELM,
-        source_format="https://github.com/org/chart/releases/download/v{{ release }}/chart-{{ release }}.tgz",
+        source_format=(
+            "https://github.com/org/chart/releases/download/"
+            "v{{ release }}/chart-{{ release }}.tgz"
+        ),
         bin_path="",
         repo=repo,
         retag_format="",
@@ -210,15 +213,20 @@ metadata:
     # Rollout status calls
     rollout_calls = [c for c, _ in mock_unit.run_calls if "rollout" in c and "status" in c]
     assert len(rollout_calls) == 2
-    assert ["kubectl", "rollout", "status", "deployment/calico-controller", "-n", "kube-system"] in rollout_calls
-    assert ["kubectl", "rollout", "status", "daemonset/calico-node", "-n", "kube-system"] in rollout_calls
+    expected_deploy = [
+        "kubectl", "rollout", "status", "deployment/calico-controller", "-n", "kube-system",
+    ]
+    expected_ds = [
+        "kubectl", "rollout", "status", "daemonset/calico-node", "-n", "kube-system",
+    ]
+    assert expected_deploy in rollout_calls
+    assert expected_ds in rollout_calls
 
 
 def test_verify_raises_on_helm_failure(helm_repo_component, monkeypatch):
     """When helm get manifest fails, verify raises ComponentError."""
-    from kube_galaxy.pkg.utils.shell import ShellError
-
     mock_unit = MockUnit()
+
     # Make the helm call raise
     def exploding_run(cmd, **kwargs):
         raise ShellError(cmd, 1, "", "helm not found")

--- a/tests/unit/components/test_helm.py
+++ b/tests/unit/components/test_helm.py
@@ -1,0 +1,230 @@
+"""Unit tests for helm install method."""
+
+from pathlib import Path
+
+import pytest
+
+from kube_galaxy.pkg.cluster_context import ClusterContext
+from kube_galaxy.pkg.components._base import ComponentBase
+from kube_galaxy.pkg.literals import SystemPaths
+from kube_galaxy.pkg.manifest.models import (
+    ComponentConfig,
+    InstallConfig,
+    InstallMethod,
+    Manifest,
+    RepoInfo,
+)
+from kube_galaxy.pkg.units._base import RunResult
+from kube_galaxy.pkg.utils.errors import ClusterError, ComponentError
+from tests.unit.components.conftest import MockUnit
+
+
+@pytest.fixture
+def manifest():
+    """Create a minimal manifest for testing."""
+    return Manifest(name="test-cluster", description="Test", kubernetes_version="1.35.0")
+
+
+@pytest.fixture
+def helm_repo_config():
+    """Create a component config with helm_repo=True (repo-based install)."""
+    repo = RepoInfo(base_url="https://docs.tigera.io/calico/charts")
+    install = InstallConfig(
+        method=InstallMethod.HELM,
+        source_format="projectcalico/tigera-operator",
+        bin_path="",
+        repo=repo,
+        retag_format="",
+        helm_repo=True,
+    )
+    return ComponentConfig(
+        name="calico",
+        category="projectcalico/calico",
+        release="3.30.6",
+        installation=install,
+    )
+
+
+@pytest.fixture
+def helm_archive_config():
+    """Create a component config with helm_repo=False (archive-based install)."""
+    repo = RepoInfo(base_url="https://github.com/org/chart")
+    install = InstallConfig(
+        method=InstallMethod.HELM,
+        source_format="https://github.com/org/chart/releases/download/v{{ release }}/chart-{{ release }}.tgz",
+        bin_path="",
+        repo=repo,
+        retag_format="",
+        helm_repo=False,
+    )
+    return ComponentConfig(
+        name="my-chart",
+        category="org/chart",
+        release="1.2.3",
+        installation=install,
+    )
+
+
+@pytest.fixture
+def helm_repo_component(manifest, arch_info, helm_repo_config, monkeypatch, tmp_path):
+    """ComponentBase with helm_repo=True."""
+    monkeypatch.setattr(SystemPaths, "staging_root", classmethod(lambda cls: tmp_path))
+    return ComponentBase(ClusterContext(), manifest, helm_repo_config, arch_info)
+
+
+@pytest.fixture
+def helm_archive_component(manifest, arch_info, helm_archive_config, monkeypatch, tmp_path):
+    """ComponentBase with helm_repo=False."""
+    monkeypatch.setattr(SystemPaths, "staging_root", classmethod(lambda cls: tmp_path))
+    return ComponentBase(ClusterContext(), manifest, helm_archive_config, arch_info)
+
+
+# --- download hook tests ---
+
+
+def test_download_skips_when_helm_repo(helm_repo_component, monkeypatch):
+    """When helm_repo=True, download_hook does not download anything."""
+    download_calls = []
+
+    def fake_download_file(url, dest):
+        download_calls.append((url, dest))
+
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.components.strategies._base.download_file", fake_download_file
+    )
+
+    helm_repo_component.download_hook()
+
+    assert len(download_calls) == 0
+    assert helm_repo_component.chart_path is None
+
+
+def test_download_fetches_chart_archive(helm_archive_component, monkeypatch, tmp_path):
+    """When helm_repo=False, download_hook downloads the chart archive."""
+    download_calls = []
+
+    def fake_download_file(url, dest):
+        download_calls.append((url, dest))
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"fake-tgz")
+
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.components.strategies._base.download_file", fake_download_file
+    )
+
+    helm_archive_component.download_hook()
+
+    assert len(download_calls) == 1
+    url, dest = download_calls[0]
+    assert "chart-1.2.3.tgz" in url
+    assert helm_archive_component.chart_path == dest
+    assert dest.exists()
+
+
+# --- bootstrap hook tests ---
+
+
+def test_bootstrap_from_repo(helm_repo_component, monkeypatch):
+    """When helm_repo=True, bootstrap adds repo and installs from it."""
+    repo_add_calls = []
+    install_repo_calls = []
+
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.components.strategies.helm.helm_repo_add",
+        lambda unit, name, url: repo_add_calls.append((name, url)),
+    )
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.components.strategies.helm.helm_install_from_repo",
+        lambda unit, release, chart: install_repo_calls.append((release, chart)),
+    )
+
+    helm_repo_component.bootstrap_hook()
+
+    assert repo_add_calls == [("projectcalico", "https://docs.tigera.io/calico/charts")]
+    assert install_repo_calls == [("calico", "projectcalico/tigera-operator")]
+
+
+def test_bootstrap_from_archive(helm_archive_component, monkeypatch, tmp_path):
+    """When helm_repo=False and chart exists, bootstrap installs from archive."""
+    install_archive_calls = []
+
+    chart_path = tmp_path / "chart-1.2.3.tgz"
+    chart_path.write_bytes(b"fake-tgz")
+    helm_archive_component.chart_path = chart_path
+
+    monkeypatch.setattr(
+        "kube_galaxy.pkg.components.strategies.helm.helm_install_from_archive",
+        lambda unit, release, path: install_archive_calls.append((release, path)),
+    )
+
+    helm_archive_component.bootstrap_hook()
+
+    assert install_archive_calls == [("my-chart", chart_path)]
+
+
+def test_bootstrap_raises_if_chart_missing(helm_archive_component):
+    """When helm_repo=False and chart_path is None, bootstrap raises ComponentError."""
+    with pytest.raises(ComponentError, match="chart not downloaded"):
+        helm_archive_component.bootstrap_hook()
+
+
+# --- verify hook tests ---
+
+
+def test_verify_waits_for_workloads(helm_repo_component, monkeypatch):
+    """Verify hook gets helm manifest and waits for workload rollout."""
+    manifest_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calico-controller
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-svc
+"""
+    mock_unit = MockUnit()
+    mock_unit.set_run_results(
+        RunResult(0, manifest_yaml, ""),  # helm get manifest
+        RunResult(0, "", ""),  # rollout status Deployment
+        RunResult(0, "", ""),  # rollout status DaemonSet
+    )
+    helm_repo_component.unit = mock_unit  # type: ignore[assignment]
+
+    helm_repo_component.verify_hook()
+
+    # First call is helm get manifest
+    helm_cmd = mock_unit.run_calls[0][0]
+    assert "helm" in helm_cmd
+    assert "get" in helm_cmd
+    assert "manifest" in helm_cmd
+
+    # Rollout status calls
+    rollout_calls = [c for c, _ in mock_unit.run_calls if "rollout" in c and "status" in c]
+    assert len(rollout_calls) == 2
+    assert ["kubectl", "rollout", "status", "deployment/calico-controller", "-n", "kube-system"] in rollout_calls
+    assert ["kubectl", "rollout", "status", "daemonset/calico-node", "-n", "kube-system"] in rollout_calls
+
+
+def test_verify_raises_on_helm_failure(helm_repo_component, monkeypatch):
+    """When helm get manifest fails, verify raises ComponentError."""
+    from kube_galaxy.pkg.utils.shell import ShellError
+
+    mock_unit = MockUnit()
+    # Make the helm call raise
+    def exploding_run(cmd, **kwargs):
+        raise ShellError(cmd, 1, "", "helm not found")
+
+    mock_unit.run = exploding_run  # type: ignore[assignment]
+    helm_repo_component.unit = mock_unit  # type: ignore[assignment]
+
+    with pytest.raises(ComponentError, match="Failed to get helm manifest"):
+        helm_repo_component.verify_hook()


### PR DESCRIPTION
## Summary

Adds a `helm` installation method to kube-galaxy-test, enabling components to be installed via Helm charts rather than raw `kubectl apply` manifests.

Resolves KU-5580.

## Changes

- **New `InstallMethod.HELM`** enum value and `helm_repo` boolean field on `InstallConfig`
- **`src/kube_galaxy/pkg/utils/helm.py`** — Helm CLI wrapper utilities (`helm`, `helm_repo_add`, `helm_install_from_repo`, `helm_install_from_archive`)
- **`src/kube_galaxy/pkg/components/strategies/helm.py`** — Strategy with `_download`, `_bootstrap`, `_verify` hooks following the same pattern as `container_manifest.py`
- **`smoketest.yaml`** — Added helm binary (v4.1.4) as a `binary-archive` component

## Two installation approaches (Calico example)

The strategy supports two modes, controlled by the `helm-repo` manifest key:

**1. Archive (default)** — Downloads `.tgz` chart from a URL (e.g. GitHub releases):
```
- name: calico-crds
  category: projectcalico/calico
  release: &calico-version "3.32.0"
  installation:
    method: helm
    repo:
      base-url: https://github.com/projectcalico/calico
    source-format: "{{ repo.base-url }}/releases/download/v{{ release }}/crd.projectcalico.org.v1-v{{ release }}.tgz"

- name: calico
  category: projectcalico/calico
  release: *calico-version
  installation:
    method: helm
    repo:
      base-url: https://github.com/projectcalico/calico
    source-format: "{{ repo.base-url }}/releases/download/v{{ release }}/tigera-operator-v{{ release }}.tgz"
```

**2. Chart repository** (`helm-repo: true`) — Adds a helm repo and installs by chart reference:
```
- name: calico-crds
  category: projectcalico/calico
  release: &calico-version "3.32.0"
  installation:
    method: helm
    helm-repo: true
    repo:
      base-url: https://docs.tigera.io/calico/charts
    source-format: "projectcalico/crd.projectcalico.org.v1"

- name: calico
  category: projectcalico/calico
  release: *calico-version
  installation:
    method: helm
    helm-repo: true
    repo:
      base-url: https://docs.tigera.io/calico/charts
    source-format: "projectcalico/tigera-operator"
```