### PR TITLE
fix: use tmate instead of upterm

### DIFF
--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -227,12 +227,10 @@ jobs:
           path: debug-logs/
           retention-days: 30
 
-      - name: Setup upterm session for debugging
+      - name: Tmate debugging session
         if: failure() && github.event_name == 'pull_request'
-        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
-        timeout-minutes: 5
-        with:
-          limit-access-to-actor: true
+        uses: canonical/action-tmate@main
+        timeout-minutes: 30
 
       - name: Create Issue on Failure
         if: failure() && inputs.create-issues-on-failure

--- a/.github/workflows/reusable-cluster-test.yml
+++ b/.github/workflows/reusable-cluster-test.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Tmate debugging session
         if: failure() && github.event_name == 'pull_request'
-        uses: canonical/action-tmate@main
+        uses: canonical/action-tmate@5f11b26528699b78dadfb61273f4c859ac7145cf  # main
         timeout-minutes: 30
 
       - name: Create Issue on Failure


### PR DESCRIPTION
This PR changes the debug step in the reusable cluster test workflow to use tmate instead of upterm. Notwithstanding that the debug step using upterm is broken (likely to due to a networking config issue), our custom tmate action is more secure and less susceptible to secret compromise.