### PR TITLE
fix: switch from containerd config from conf.d to hosts.d

### DIFF
--- a/src/kube_galaxy/pkg/components/containerd.py
+++ b/src/kube_galaxy/pkg/components/containerd.py
@@ -19,6 +19,13 @@ HOSTS_D = Path("/etc/containerd/hosts.d")
 CONF_D = Path("/etc/containerd/conf.d")
 
 
+def _registry_server(host: str) -> str:
+    """Map a registry host to its server URL."""
+    if host == "docker.io":
+        return "https://registry-1.docker.io"
+    return f"https://{host}"
+
+
 def _registry_auth(component: "ComponentBase", host: str, auth: str) -> None:
     """
     Write a hosts.toml file for containerd registry authentication.
@@ -36,9 +43,10 @@ def _registry_auth(component: "ComponentBase", host: str, auth: str) -> None:
     strip_basic = auth.split(" ", 1)[-1] if auth.startswith("Basic ") else None
     if strip_basic:
         info(f"  Found Basic auth for {host}, writing containerd hosts.toml with credentials")
-        content = hosts_tmpl.read_text().format(host=host, authorization=strip_basic)
-        host_auth_toml = CONF_D / f"{host}.toml"
-        component.write_config_file(content, host_auth_toml, mode=Permissions.PRIVATE)
+        server = _registry_server(host)
+        content = hosts_tmpl.read_text().format(server=server, authorization=strip_basic)
+        hosts_toml = HOSTS_D / host / "hosts.toml"
+        component.write_config_file(content, hosts_toml, mode=Permissions.PRIVATE)
 
 
 def _registry_mirror(component: "ComponentBase") -> None:

--- a/src/kube_galaxy/pkg/components/templates/containerd/auth-hosts.toml
+++ b/src/kube_galaxy/pkg/components/templates/containerd/auth-hosts.toml
@@ -1,2 +1,6 @@
-[plugins."io.containerd.grpc.v1.cri".registry.configs."{host}".auth]
-  auth = "{authorization}"
+server = "{server}"
+
+[host."{server}"]
+  capabilities = ["pull", "resolve"]
+  [host."{server}".header]
+    Authorization = ["Basic {authorization}"]


### PR DESCRIPTION
In 2.x containerd, config files for containerd are expected to be written in `/etc/containerd/hosts.d`, but our code was writing auth secrets to `/etc/containerd/conf.d`, which is what was expected in 1.x containerd: https://github.com/containerd/containerd/blob/main/docs/hosts.md 

This was causing our authentication to not get passed in for dockerhub, which is why we have been hitting rate-limits on image pulls. This PR switches to writing the auths to hosts.d